### PR TITLE
Correct marketplace installation step in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ You can add this marketplace using either the short form or full URL:
 
 ```bash
 # Short form (GitHub owner/repo)
-/plugin marketplace add bitwarden/ai-marketplace
+/plugin marketplace add bitwarden/ai-plugins
 
 # Full GitHub URL
-/plugin marketplace add https://github.com/bitwarden/ai-marketplace
+/plugin marketplace add https://github.com/bitwarden/ai-plugins
 ```
 
 **Note:** After adding the marketplace, you will need to restart Claude Code for the changes to take effect.


### PR DESCRIPTION
Correct the commands used to add a marketplace and install plugins.

## 🎟️ Tracking

N/A

## 📔 Objective

Update README to provide the correct commands for adding a marketplace using Claude commands.

The correct command, after launching Claude, is..
```bash
/plugin marketplace add bitwarden/ai-plugins
```

or

```bash
/plugin marketplace add https://github.com/bitwarden/ai-plugins
```

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
