### PR TITLE
Get history with validation step in plugin validator

### DIFF
--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           persist-credentials: false
+          fetch-depth: 0
 
       - name: Get changed plugin files
         id: changed-files


### PR DESCRIPTION
## 🎟️ Tracking

Issue seen from the addition of the validator in https://github.com/bitwarden/ai-plugins/pull/21, at https://github.com/bitwarden/ai-plugins/pull/15.

## 📔 Objective

The validation workflow was failing with a fatal error when computing changed files between branches. The workflow used a shallow git clone (default behavior) but needed full history to run `git diff` commands between the base branch and PR head.

Added `fetch-depth: 0` to the checkout action to fetch full git history instead of a shallow clone. This allows the workflow to properly compute diffs and identify changed plugin files across branch merges.