### PR TITLE
Detect agent definitions in more places as well as skills

### DIFF
--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -144,11 +144,18 @@ jobs:
             Perform TWO types of validation:
 
             ## 1. Component Validation (using the plugin-dev agent)
-            For each AGENT.md, SKILL.md, and hooks.json file:
-            - Validate agent/skill identifiers (3-50 chars, lowercase, hyphens only)
+            For AGENT.md files:
+            - Validate agent identifiers (3-50 chars, lowercase, hyphens only)
             - Validate description length (10-5,000 chars)
-            - Validate system prompt length (20-10,000 chars) for agents
+            - Validate system prompt length (20-10,000 chars)
             - Check YAML frontmatter structure
+
+            For SKILL.md files:
+            - Validate skill name (max 64 chars)
+            - Validate description length (max 1024 chars)
+            - Check YAML frontmatter structure
+
+            For hooks.json files:
             - Validate hook JSON schema
             - Check hook event names
             - Verify script paths use ${CLAUDE_PLUGIN_ROOT}


### PR DESCRIPTION
## 🎟️ Tracking

More testing on #15.

## 📔 Objective

The workflow now correctly understands the Claude Code plugin marketplace structure where:
- Agents are in subdirectories: plugins/{plugin}/agents/{agent-name}/AGENT.md
- Skills are in subdirectories: plugins/{plugin}/skills/{skill-name}/SKILL.md
- Hooks are at plugin root: plugins/{plugin}/.claude-plugin/hooks.json

and the validator will now analyze skills as well.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
