### PR TITLE
Fix Claude Code Action parameters

### DIFF
--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -122,9 +122,9 @@ jobs:
           USE_SIMPLE_PROMPT: "true"
         with:
           anthropic_api_key: ${{ steps.get-kv-secrets.outputs.ANTHROPIC-CODE-REVIEW-API-KEY }}
-          track_progress: false
-          use_sticky_comment: false
-          plugin_marketplaces: "git+https://github.com/bitwarden/ai-plugins.git"
+          track_progress: true
+          use_sticky_comment: true
+          plugin_marketplaces: "https://github.com/bitwarden/ai-plugins.git"
           plugins: "plugin-dev, claude-config-validator@bitwarden-marketplace"
           prompt: |
             Review the following plugin configuration files for compliance with Claude Code plugin standards and security best practices.


### PR DESCRIPTION
## 🎟️ Tracking

More testing on https://github.com/bitwarden/ai-plugins/pull/15.

## 📔 Objective

Claude seems unhappy with the local Git-based reference to the marketplace. Also uses progress tracking and a sticky comment which is the norm for us now.