### PR TITLE
Open up agent filename acceptance and properly provide marketplace paths

### DIFF
--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -39,8 +39,10 @@ jobs:
           CHANGED_PLUGINS=$(echo "$CHANGED_FILES" | cut -d/ -f1-2 | sort -u | tr '\n' ' ' | sed 's/ $//')
 
           # Filter for AGENT.md, SKILL.md, and hooks.json files
-          # Agent files are in plugins/*/agents/*/AGENT.md
-          AGENT_FILES=$(echo "$CHANGED_FILES" | grep '/agents/.*/AGENT\.md$' || echo "")
+          # Agent files can be in two patterns:
+          #   1. plugins/*/agents/*/AGENT.md (subdirectory with AGENT.md)
+          #   2. plugins/*/agents/*.md (direct .md files in agents directory)
+          AGENT_FILES=$(echo "$CHANGED_FILES" | grep -E '/agents/.*\.md$' || echo "")
           # Skill files are in plugins/*/skills/*/SKILL.md
           SKILL_FILES=$(echo "$CHANGED_FILES" | grep '/skills/.*/SKILL\.md$' || echo "")
           HOOK_FILES=$(echo "$CHANGED_FILES" | grep 'hooks\.json$' || echo "")
@@ -124,8 +126,8 @@ jobs:
           anthropic_api_key: ${{ steps.get-kv-secrets.outputs.ANTHROPIC-CODE-REVIEW-API-KEY }}
           track_progress: true
           use_sticky_comment: true
-          plugin_marketplaces: "https://github.com/bitwarden/ai-plugins.git"
-          plugins: "plugin-dev, claude-config-validator@bitwarden-marketplace"
+          plugin_marketplaces: "https://github.com/anthropics/claude-code.git, https://github.com/bitwarden/ai-plugins.git"
+          plugins: "plugin-dev@anthropics, claude-config-validator@bitwarden-marketplace"
           prompt: |
             Review the following plugin configuration files for compliance with Claude Code plugin standards and security best practices.
 


### PR DESCRIPTION
## 🎟️ Tracking

More testing on https://github.com/bitwarden/ai-plugins/pull/15.

## 📔 Objective

Decided to open up the agent file naming, at least for now, because it helps my testing and is technically accepted. I don't think we have to standardize necessarily if it works for Claude.

Also properly configures the Anthropic marketplace path, which I thought was implied.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
