### PR TITLE
Use marketplace name for Claude Code plugins

### DIFF
--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -130,7 +130,7 @@ jobs:
             https://github.com/anthropics/claude-code.git
             https://github.com/bitwarden/ai-plugins.git
           plugins: |
-            plugin-dev@anthropics
+            plugin-dev@claude-code-plugins
             claude-config-validator@bitwarden-marketplace
           prompt: |
             Review the following plugin configuration files for compliance with Claude Code plugin standards and security best practices.


### PR DESCRIPTION
## 🎟️ Tracking

More testing on https://github.com/bitwarden/ai-plugins/pull/15.

## 📔 Objective

The [marketplace](https://github.com/anthropics/claude-code/blob/main/.claude-plugin/marketplace.json) name isn't the org name on GitHub.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
