### PR TITLE
Add temporary debug statements to validator

### DIFF
--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -79,8 +79,16 @@ jobs:
         run: |
           set -o pipefail
           echo "Validating changed plugins: $CHANGED_PLUGINS"
-          read -ra PLUGINS_ARRAY <<< "$CHANGED_PLUGINS"
-          ./scripts/validate-plugin-structure.sh "${PLUGINS_ARRAY[@]}" 2>&1 | tee /tmp/structure-validation.log
+          echo "DEBUG: Length of CHANGED_PLUGINS: ${#CHANGED_PLUGINS}"
+          echo "DEBUG: CHANGED_PLUGINS (hex): $(echo -n "$CHANGED_PLUGINS" | od -A n -t x1)"
+          if [[ -n "$CHANGED_PLUGINS" ]]; then
+            IFS=' ' read -r -a PLUGINS_ARRAY <<< "$CHANGED_PLUGINS"
+            echo "DEBUG: Array length: ${#PLUGINS_ARRAY[@]}"
+            echo "DEBUG: Array contents: ${PLUGINS_ARRAY[@]}"
+            ./scripts/validate-plugin-structure.sh "${PLUGINS_ARRAY[@]}" 2>&1 | tee /tmp/structure-validation.log
+          else
+            echo "DEBUG: CHANGED_PLUGINS is empty, skipping validation"
+          fi
 
       - name: Validate marketplace.json
         id: marketplace
@@ -91,8 +99,16 @@ jobs:
         run: |
           set -o pipefail
           echo "Validating marketplace entries for changed plugins: $CHANGED_PLUGINS"
-          read -ra PLUGINS_ARRAY <<< "$CHANGED_PLUGINS"
-          ./scripts/validate-marketplace.sh "${PLUGINS_ARRAY[@]}" 2>&1 | tee /tmp/marketplace-validation.log
+          echo "DEBUG: Length of CHANGED_PLUGINS: ${#CHANGED_PLUGINS}"
+          echo "DEBUG: CHANGED_PLUGINS (hex): $(echo -n "$CHANGED_PLUGINS" | od -A n -t x1)"
+          if [[ -n "$CHANGED_PLUGINS" ]]; then
+            IFS=' ' read -r -a PLUGINS_ARRAY <<< "$CHANGED_PLUGINS"
+            echo "DEBUG: Array length: ${#PLUGINS_ARRAY[@]}"
+            echo "DEBUG: Array contents: ${PLUGINS_ARRAY[@]}"
+            ./scripts/validate-marketplace.sh "${PLUGINS_ARRAY[@]}" 2>&1 | tee /tmp/marketplace-validation.log
+          else
+            echo "DEBUG: CHANGED_PLUGINS is empty, skipping validation"
+          fi
 
       - name: Log in to Azure
         if: steps.changed-files.outputs.has_components == 'true'

--- a/scripts/validate-marketplace.sh
+++ b/scripts/validate-marketplace.sh
@@ -284,15 +284,21 @@ main() {
     # Build list of plugins to validate
     local target_plugins=()
     if [[ $# -gt 0 ]]; then
+        echo "DEBUG: Received $# argument(s): $*"
         # Arguments provided - extract plugin names
         for arg in "$@"; do
+            echo "DEBUG: Processing argument: '$arg'"
             # Use shared sanitization function to safely parse plugin path
             local sanitized_path
-            if sanitized_path=$(sanitize_plugin_path "$arg" "$REPO_ROOT/plugins" 2>/dev/null); then
+            if sanitized_path=$(sanitize_plugin_path "$arg" "$REPO_ROOT/plugins" 2>&1); then
                 # Extract just the plugin name from the full path
                 local plugin_name
                 plugin_name=$(basename "$sanitized_path")
+                echo "DEBUG: ✓ Sanitized to: '$sanitized_path' → plugin name: '$plugin_name'"
                 target_plugins+=("$plugin_name")
+            else
+                echo "DEBUG: ✗ Failed to sanitize argument '$arg'"
+                echo "DEBUG:   Output from sanitize_plugin_path: $sanitized_path"
             fi
         done
 

--- a/scripts/validate-plugin-structure.sh
+++ b/scripts/validate-plugin-structure.sh
@@ -369,11 +369,17 @@ main() {
 
     # If arguments provided, validate only those plugins
     if [[ $# -gt 0 ]]; then
+        echo "DEBUG: Received $# argument(s): $*"
         for arg in "$@"; do
+            echo "DEBUG: Processing argument: '$arg'"
             # Use shared sanitization function to safely parse plugin path
             local sanitized_path
-            if sanitized_path=$(sanitize_plugin_path "$arg" "$PLUGINS_DIR" 2>/dev/null); then
+            if sanitized_path=$(sanitize_plugin_path "$arg" "$PLUGINS_DIR" 2>&1); then
+                echo "DEBUG: ✓ Sanitized to: '$sanitized_path'"
                 plugins+=("$sanitized_path")
+            else
+                echo "DEBUG: ✗ Failed to sanitize argument '$arg'"
+                echo "DEBUG:   Output from sanitize_plugin_path: $sanitized_path"
             fi
         done
 


### PR DESCRIPTION
## 🎟️ Tracking

More testing on https://github.com/bitwarden/ai-plugins/pull/15.

## 📔 Objective

We're still having issues running the validator scripts in GitHub Actions, but these run fine locally. Adding some debugging statements temporarily to try to figure out where the problems are.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
