### PR TITLE
Apply regex fix and undo debug output

### DIFF
--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -79,16 +79,8 @@ jobs:
         run: |
           set -o pipefail
           echo "Validating changed plugins: $CHANGED_PLUGINS"
-          echo "DEBUG: Length of CHANGED_PLUGINS: ${#CHANGED_PLUGINS}"
-          echo "DEBUG: CHANGED_PLUGINS (hex): $(echo -n "$CHANGED_PLUGINS" | od -A n -t x1)"
-          if [[ -n "$CHANGED_PLUGINS" ]]; then
-            IFS=' ' read -r -a PLUGINS_ARRAY <<< "$CHANGED_PLUGINS"
-            echo "DEBUG: Array length: ${#PLUGINS_ARRAY[@]}"
-            echo "DEBUG: Array contents: ${PLUGINS_ARRAY[@]}"
-            ./scripts/validate-plugin-structure.sh "${PLUGINS_ARRAY[@]}" 2>&1 | tee /tmp/structure-validation.log
-          else
-            echo "DEBUG: CHANGED_PLUGINS is empty, skipping validation"
-          fi
+          read -ra PLUGINS_ARRAY <<< "$CHANGED_PLUGINS"
+          ./scripts/validate-plugin-structure.sh "${PLUGINS_ARRAY[@]}" 2>&1 | tee /tmp/structure-validation.log
 
       - name: Validate marketplace.json
         id: marketplace
@@ -99,16 +91,8 @@ jobs:
         run: |
           set -o pipefail
           echo "Validating marketplace entries for changed plugins: $CHANGED_PLUGINS"
-          echo "DEBUG: Length of CHANGED_PLUGINS: ${#CHANGED_PLUGINS}"
-          echo "DEBUG: CHANGED_PLUGINS (hex): $(echo -n "$CHANGED_PLUGINS" | od -A n -t x1)"
-          if [[ -n "$CHANGED_PLUGINS" ]]; then
-            IFS=' ' read -r -a PLUGINS_ARRAY <<< "$CHANGED_PLUGINS"
-            echo "DEBUG: Array length: ${#PLUGINS_ARRAY[@]}"
-            echo "DEBUG: Array contents: ${PLUGINS_ARRAY[@]}"
-            ./scripts/validate-marketplace.sh "${PLUGINS_ARRAY[@]}" 2>&1 | tee /tmp/marketplace-validation.log
-          else
-            echo "DEBUG: CHANGED_PLUGINS is empty, skipping validation"
-          fi
+          read -ra PLUGINS_ARRAY <<< "$CHANGED_PLUGINS"
+          ./scripts/validate-marketplace.sh "${PLUGINS_ARRAY[@]}" 2>&1 | tee /tmp/marketplace-validation.log
 
       - name: Log in to Azure
         if: steps.changed-files.outputs.has_components == 'true'

--- a/scripts/lib/path-sanitization.sh
+++ b/scripts/lib/path-sanitization.sh
@@ -48,9 +48,15 @@ sanitize_plugin_path() {
     local arg="$1"
     local plugins_dir="$2"
 
-    # Reject paths containing null bytes, newlines, or carriage returns
-    if [[ "$arg" =~ $'\0' ]] || [[ "$arg" =~ $'\n' ]] || [[ "$arg" =~ $'\r' ]]; then
-        echo "ERROR: Path contains invalid characters (null/newline/carriage return)" >&2
+    # Reject paths containing newlines or carriage returns
+    # Note: Null bytes can't exist in bash strings (they terminate strings),
+    # so we only need to check for newline and carriage return
+    if [[ "$arg" == *$'\n'* ]]; then
+        echo "ERROR: Path contains newline" >&2
+        return 1
+    fi
+    if [[ "$arg" == *$'\r'* ]]; then
+        echo "ERROR: Path contains carriage return" >&2
         return 1
     fi
 

--- a/scripts/validate-marketplace.sh
+++ b/scripts/validate-marketplace.sh
@@ -284,21 +284,15 @@ main() {
     # Build list of plugins to validate
     local target_plugins=()
     if [[ $# -gt 0 ]]; then
-        echo "DEBUG: Received $# argument(s): $*"
         # Arguments provided - extract plugin names
         for arg in "$@"; do
-            echo "DEBUG: Processing argument: '$arg'"
             # Use shared sanitization function to safely parse plugin path
             local sanitized_path
-            if sanitized_path=$(sanitize_plugin_path "$arg" "$REPO_ROOT/plugins" 2>&1); then
+            if sanitized_path=$(sanitize_plugin_path "$arg" "$REPO_ROOT/plugins" 2>/dev/null); then
                 # Extract just the plugin name from the full path
                 local plugin_name
                 plugin_name=$(basename "$sanitized_path")
-                echo "DEBUG: ✓ Sanitized to: '$sanitized_path' → plugin name: '$plugin_name'"
                 target_plugins+=("$plugin_name")
-            else
-                echo "DEBUG: ✗ Failed to sanitize argument '$arg'"
-                echo "DEBUG:   Output from sanitize_plugin_path: $sanitized_path"
             fi
         done
 

--- a/scripts/validate-plugin-structure.sh
+++ b/scripts/validate-plugin-structure.sh
@@ -369,17 +369,11 @@ main() {
 
     # If arguments provided, validate only those plugins
     if [[ $# -gt 0 ]]; then
-        echo "DEBUG: Received $# argument(s): $*"
         for arg in "$@"; do
-            echo "DEBUG: Processing argument: '$arg'"
             # Use shared sanitization function to safely parse plugin path
             local sanitized_path
-            if sanitized_path=$(sanitize_plugin_path "$arg" "$PLUGINS_DIR" 2>&1); then
-                echo "DEBUG: ✓ Sanitized to: '$sanitized_path'"
+            if sanitized_path=$(sanitize_plugin_path "$arg" "$PLUGINS_DIR" 2>/dev/null); then
                 plugins+=("$sanitized_path")
-            else
-                echo "DEBUG: ✗ Failed to sanitize argument '$arg'"
-                echo "DEBUG:   Output from sanitize_plugin_path: $sanitized_path"
             fi
         done
 


### PR DESCRIPTION
## 🎟️ Tracking

More testing on https://github.com/bitwarden/ai-plugins/pull/15.

## 📔 Objective

The bug was in the invalid character check: `[[ "$arg" =~ $'\0' ]]` used a regex with `$'\0'` (null byte), which expands to an empty string, creating an invalid regex that matched everything. Changed from regex `=~` to glob pattern matching `==` for newline and carriage return checks. Removed the null byte check entirely too -- bash strings can't contain null bytes anyway.

Removed the debug code as a result.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
