### PR TITLE
Bump Claude Code to v 1.0.29

### DIFF
--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -118,7 +118,7 @@ jobs:
         id: components
         if: steps.changed-files.outputs.has_components == 'true'
         continue-on-error: true
-        uses: anthropics/claude-code-action@0d1933529914177075d5bc3558ae3d047f188146 # v1.0.26
+        uses: anthropics/claude-code-action@1b8ee3b94104046d71fde52ec3557651ad8c0d71 # v1.0.29
         env:
           USE_AGENT_SDK: "true"
           USE_SIMPLE_PROMPT: "true"


### PR DESCRIPTION
## 🎟️ Tracking

## 📔 Objective

Primary objective in bumping to [v1.0.29](https://github.com/anthropics/claude-code-action/releases/tag/v1.0.29) is the resolution of [CVE-2025-66414](https://github.com/advisories/GHSA-w48q-cv73-mx4w).