### PR TITLE
Enhance skill front matter & add plugin name to agent when invoking the task

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -25,7 +25,7 @@
     {
       "name": "bitwarden-code-review",
       "source": "./plugins/bitwarden-code-review",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "description": "Comprehensive code review system with organization-wide standards."
     },
     {

--- a/plugins/bitwarden-code-review/.claude-plugin/plugin.json
+++ b/plugins/bitwarden-code-review/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bitwarden-code-review",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Comprehensive code review system with organization-wide standards.",
   "author": {
     "name": "Bitwarden",

--- a/plugins/bitwarden-code-review/CHANGELOG.md
+++ b/plugins/bitwarden-code-review/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the Bitwarden Code Review Plugin will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.1] - 2026-01-19
+
+### Changed
+
+- Improved the skill frontmatter using the Anthropic `skill-development` skill.
+- Updated tool invocation of the code review agent to include the name of the plugin.
+
 ## [1.7.0] - 2026-01-16
 
 ### Removed

--- a/plugins/bitwarden-code-review/agents/bitwarden-code-reviewer/AGENT.md
+++ b/plugins/bitwarden-code-review/agents/bitwarden-code-reviewer/AGENT.md
@@ -1,6 +1,6 @@
 ---
 name: bitwarden-code-reviewer
-version: 1.7.0
+version: 1.7.1
 description: Conducts thorough code reviews following Bitwarden standards. Finds all issues first pass, avoids false positives, respects codebase conventions. Invoke when user mentions "code review", "review code", "review", "PR", or "pull request".
 model: opus
 skills: avoiding-false-positives, classifying-review-findings, posting-bitwarden-review-comments, posting-review-summary, reviewing-incremental-changes

--- a/plugins/bitwarden-code-review/commands/code-review/code-review.md
+++ b/plugins/bitwarden-code-review/commands/code-review/code-review.md
@@ -4,7 +4,7 @@ allowed-tools: Read, Bash(gh pr view:*), Bash(gh pr diff:*), Bash(gh pr checks:*
 description: Review a GitHub pull request and post findings directly to GitHub
 ---
 
-You must invoke the bitwarden-code-reviewer agent to perform a comprehensive code review of a GitHub pull request or local changes.
+You must invoke the bitwarden-code-review:bitwarden-code-reviewer agent to perform a comprehensive code review of a GitHub pull request or local changes.
 
 **Steps:**
 
@@ -15,7 +15,7 @@ You must invoke the bitwarden-code-reviewer agent to perform a comprehensive cod
    - If the file does not exist (Read returns an error), proceed without thread context
 
 2. **Invoke the Task tool** with the following parameters:
-   - `subagent_type`: "bitwarden-code-reviewer"
+   - `subagent_type`: "bitwarden-code-review:bitwarden-code-reviewer"
    - `description`: "Perform code review following Bitwarden engineering standards"
    - `prompt`: Use ONE of the following based on Step 1:
 

--- a/plugins/bitwarden-code-review/skills/avoiding-false-positives/SKILL.md
+++ b/plugins/bitwarden-code-review/skills/avoiding-false-positives/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: avoiding-false-positives
-description: Prevents false positive findings by recognizing framework patterns, codebase conventions, and common non-issues. Use when uncertain whether something is a real issue.
+description: Use this skill when validating ANY potential code review finding. Apply BEFORE classifying to verify the finding is real; can you trace incorrect behavior, is it handled elsewhere, and are you certain about framework semantics? If any answer is no, DO NOT create the finding.
 ---
 
 # Avoiding False Positives

--- a/plugins/bitwarden-code-review/skills/classifying-review-findings/SKILL.md
+++ b/plugins/bitwarden-code-review/skills/classifying-review-findings/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: classifying-review-findings
-description: Classifies code review findings into severity categories (CRITICAL, IMPORTANT, DEBT, SUGGESTED, QUESTION) following Bitwarden standards. Use when determining severity levels, categorizing PR comments, deciding what emoji to use, or verifying if something should be flagged at all.
+description: Use this skill when categorizing code review findings into severity levels. Apply when determining which emoji and label to use for PR comments, deciding if an issue should be flagged at all, or classifying findings as CRITICAL, IMPORTANT, DEBT, SUGGESTED, or QUESTION.
 ---
 
 # Classifying Review Findings

--- a/plugins/bitwarden-code-review/skills/posting-bitwarden-review-comments/SKILL.md
+++ b/plugins/bitwarden-code-review/skills/posting-bitwarden-review-comments/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: posting-bitwarden-review-comments
-description: Formats and posts GitHub PR inline review comments following Bitwarden engineering standards. Use when posting code-specific findings. For summary comments, invoke posting-review-summary skill.
+description: Use this skill when posting inline comments to GitHub pull requests. Apply when formatting comments following Bitwarden engineering standards with severity emojis, clear explanations, and actionable suggestions. Use after findings are classified and ready to post. DO NOT USE when posting summary comments.
 ---
 
 # Posting Bitwarden Review Comments

--- a/plugins/bitwarden-code-review/skills/posting-review-summary/SKILL.md
+++ b/plugins/bitwarden-code-review/skills/posting-review-summary/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: posting-review-summary
-description: Posts or updates the PR summary comment. Detects context (GitHub sticky comment, GitHub new comment, or local file) and routes output accordingly. Use after all findings are classified and inline comments are posted.
+description: Use this skill when posting the final summary comment after all inline comments are posted. Apply as the LAST step of code review after all findings are classified and inline comments are complete. Detects context (GitHub sticky comment, new comment, or local file) and routes output accordingly.
 ---
 
 # Posting Review Summary

--- a/plugins/bitwarden-code-review/skills/reviewing-incremental-changes/SKILL.md
+++ b/plugins/bitwarden-code-review/skills/reviewing-incremental-changes/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: reviewing-incremental-changes
-description: Handles re-reviews after new commits. Use when a PR already has review comments or when responding to developer changes.
+description: Use this skill when re-reviewing a PR that already has comments or when responding to developer changes after initial review. Apply when PR threads exist or when reviewing force-pushed commits. Handles incremental reviews, detects addressed feedback, avoids duplicate comments, and focuses only on newly introduced issues.
 ---
 
 # Reviewing Incremental Changes


### PR DESCRIPTION
## 🎟️ Tracking

## 📔 Objective

Used the [Anthropic skill-development](https://github.com/anthropics/claude-code/blob/main/plugins/plugin-dev/skills/skill-development/SKILL.md) skill to help improve the frontmatter of our skills. 

Also found that the task tool needs to have the plugin name as a prefix to our agent name to ensure that Claude Code correctly finds it. 

Received encouraging feedback from Claude that the agent + skills are being properly invoked and Claude Code made good decisions. 

```
  Subagent

  - bitwarden-code-review:bitwarden-code-reviewer - A specialized agent that:
    - Fetched PR #6825 details from GitHub
    - Analyzed the diff and code changes
    - Checked for existing review comments
    - Determined the PR had already been reviewed on the current commit
    - Made the decision not to post duplicate findings
```