### PR TITLE
Craft read-only Atlassian Claude Skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -33,6 +33,12 @@
       "source": "./plugins/bitwarden-init",
       "version": "1.0.0",
       "description": "Initialize Claude Code configuration with Bitwarden's standardized template format"
+    },
+    {
+      "name": "atlassian-reader",
+      "source": "./plugins/atlassian-reader",
+      "version": "1.0.0",
+      "description": "Read-only access to Jira issues, epics, sprints, boards, and Confluence pages from Atlassian Cloud."
     }
   ]
 }

--- a/.cspell.json
+++ b/.cspell.json
@@ -1,7 +1,18 @@
 {
   "$schema": "https://raw.githubusercontent.com/streetsidesoftware/cspell/main/cspell.schema.json",
   "version": "0.2",
-  "words": ["anthropics", "Bitwarden", "CODEOWNERS", "semver", "frontmatter"],
+  "words": [
+    "anthropics",
+    "Bitwarden",
+    "CODEOWNERS",
+    "semver",
+    "frontmatter",
+    "atlassian",
+    "Jira",
+    "Confluence",
+    "JQL",
+    "CQL"
+  ],
   "flagWords": [],
   "ignorePaths": [
     ".vscode",

--- a/plugins/atlassian-reader/.claude-plugin/plugin.json
+++ b/plugins/atlassian-reader/.claude-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "atlassian-reader",
+  "version": "1.0.0",
+  "description": "Read-only access to Jira issues, epics, sprints, boards, and Confluence pages from Atlassian Cloud.",
+  "author": {
+    "name": "Bitwarden",
+    "url": "https://github.com/bitwarden"
+  },
+  "homepage": "https://github.com/bitwarden/ai-plugins/tree/main/plugins/atlassian-reader",
+  "repository": "https://github.com/bitwarden/ai-plugins",
+  "keywords": [
+    "atlassian",
+    "jira",
+    "confluence",
+    "sprint",
+    "agile",
+    "read-only",
+    "issue-tracking"
+  ],
+  "skills": "./skills/"
+}

--- a/plugins/atlassian-reader/CHANGELOG.md
+++ b/plugins/atlassian-reader/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to the Atlassian Reader Plugin will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0] - 2026-02-09
+
+### Added
+
+- Initial release with read-only Jira and Confluence access via scoped API tokens
+- Jira: issue reading, comments, JQL search, boards and sprints
+- Confluence: page reading, CQL search, child page listing
+- Error handling and context-aware summarization
+
+---
+
+## Version Format
+
+Plugin version tracks base guidelines changes:
+
+- **Major version**: Breaking changes to base guidelines or emoji system
+- **Minor version**: New organizational patterns added to base guidelines, or new tool additions.
+- **Patch version**: Bug fixes, clarifications, documentation improvements

--- a/plugins/atlassian-reader/README.md
+++ b/plugins/atlassian-reader/README.md
@@ -1,0 +1,44 @@
+# Atlassian Reader Plugin
+
+Read-only access to Jira and Confluence from Atlassian Cloud. Mention a Jira ticket, ask about a sprint, or reference a Confluence page — the skill fetches and summarizes the data. No scripts, no MCP servers, just curl templates in a single SKILL.md.
+
+## Prerequisites
+
+### Environment Variables
+
+| Variable                               | Purpose                                                           |
+| -------------------------------------- | ----------------------------------------------------------------- |
+| `ATLASSIAN_CLOUD_ID`                   | Cloud ID from `https://bitwarden.atlassian.net/_edge/tenant_info` |
+| `ATLASSIAN_EMAIL`                      | Atlassian account email                                           |
+| `ATLASSIAN_JIRA_READ_ONLY_TOKEN`       | Scoped Jira view-only API token                                   |
+| `ATLASSIAN_CONFLUENCE_READ_ONLY_TOKEN` | Scoped Confluence view-only API token                             |
+
+Two separate tokens are required because Atlassian scoped tokens are per-product. Create them at [Atlassian API tokens](https://id.atlassian.com/manage-profile/security/api-tokens) with **view-only** scope.
+
+### Dependencies
+
+- `curl`
+- `jq` (`brew install jq` or `apt-get install jq`)
+
+## Installation
+
+```bash
+/plugin marketplace add bitwarden/ai-marketplace
+
+/plugin install atlassian-reader@bitwarden-marketplace
+```
+
+## Usage
+
+```
+Read PROJ-123
+What's in the current sprint for PROJ?
+Search Confluence for "API rate limiting" in the Engineering space
+```
+
+## Security
+
+- **Scoped read-only tokens**: View-only permissions enforced server-side by Atlassian's API gateway. Tokens cannot modify data.
+- **Per-product isolation**: Separate Jira and Confluence tokens. A compromised token for one product cannot access the other.
+- **No stored credentials**: Tokens read from environment variables at runtime.
+- **Restricted tool access**: Only `curl` commands are permitted.

--- a/plugins/atlassian-reader/skills/atlassian-reader/SKILL.md
+++ b/plugins/atlassian-reader/skills/atlassian-reader/SKILL.md
@@ -1,0 +1,266 @@
+---
+name: atlassian-reader
+description: Reads Jira issues, epics, stories, sprints, boards, and Confluence pages from Atlassian Cloud into context via READ-ONLY scoped API tokens and curl commands. Use when the user mentions a Jira ticket (e.g. PROJ-123), references a Confluence page or URL, asks about sprint status, needs epic child stories, or wants to review linked documents for a Jira issue.
+---
+
+# Atlassian Reader
+
+Read-only access to Jira and Confluence via Atlassian Cloud REST APIs using **scoped read-only API tokens**. All operations use curl with Basic Auth through the Atlassian API gateway (`api.atlassian.com`). **Never create, update, or delete any Atlassian resource.**
+
+## 1. Environment Variables
+
+This skill requires four environment variables. **Do not run any verification commands** — go straight to the API call. If it fails, consult the error handling section (Section 11) to diagnose the cause and guide the user.
+
+| Variable                               | Purpose                                                                                                                                     |
+| -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ATLASSIAN_CLOUD_ID`                   | Bitwarden Atlassian Cloud ID (find it at `https://bitwarden.atlassian.net/_edge/tenant_info`)                                               |
+| `ATLASSIAN_EMAIL`                      | Email address associated with the Atlassian account                                                                                         |
+| `ATLASSIAN_JIRA_READ_ONLY_TOKEN`       | Scoped Jira API token with **read** permissions only ([create one here](https://id.atlassian.com/manage-profile/security/api-tokens))       |
+| `ATLASSIAN_CONFLUENCE_READ_ONLY_TOKEN` | Scoped Confluence API token with **read** permissions only ([create one here](https://id.atlassian.com/manage-profile/security/api-tokens)) |
+
+**Why two tokens?** Atlassian scoped tokens are per-product. A Jira-scoped token cannot access Confluence and vice versa. This enforces least-privilege: each token only has read access to its respective product.
+
+## 2. Discovery
+
+Use when the user doesn't specify a project key or space key, or asks what they have access to.
+
+### List Jira Projects
+
+```bash
+curl -s --connect-timeout 10 --max-time 30 \
+  -H "Authorization: Basic $(printf '%s:%s' "$ATLASSIAN_EMAIL" "$ATLASSIAN_JIRA_READ_ONLY_TOKEN" | base64)" \
+  -H "Accept: application/json" \
+  "https://api.atlassian.com/ex/jira/${ATLASSIAN_CLOUD_ID}/rest/api/3/project" | jq .
+```
+
+Present as a table: Key, Name, Type. Use the project key to resolve `{{PROJECT}}` in subsequent JQL or board queries.
+
+### List Confluence Spaces
+
+```bash
+curl -s --connect-timeout 10 --max-time 30 \
+  -H "Authorization: Basic $(printf '%s:%s' "$ATLASSIAN_EMAIL" "$ATLASSIAN_CONFLUENCE_READ_ONLY_TOKEN" | base64)" \
+  -H "Accept: application/json" \
+  "https://api.atlassian.com/ex/confluence/${ATLASSIAN_CLOUD_ID}/rest/api/space?limit=25&type=global" | jq .
+```
+
+Present as a table: Key, Name, Type. Use the space key to resolve `{{SPACE_KEY}}` in subsequent CQL queries.
+
+## 3. Read Jira Issue
+
+Use when the user references a ticket ID like `PROJ-123`, asks about a story, or wants issue details.
+
+```bash
+curl -s --connect-timeout 10 --max-time 30 \
+  -H "Authorization: Basic $(printf '%s:%s' "$ATLASSIAN_EMAIL" "$ATLASSIAN_JIRA_READ_ONLY_TOKEN" | base64)" \
+  -H "Accept: application/json" \
+  "https://api.atlassian.com/ex/jira/${ATLASSIAN_CLOUD_ID}/rest/api/3/issue/{{TICKET_ID}}?fields=summary,description,status,issuetype,priority,assignee,reporter,comment,subtasks,issuelinks,parent,labels,components,sprint&expand=renderedFields" | jq .
+```
+
+Replace `{{TICKET_ID}}` with the actual issue key (e.g. `PROJ-123`).
+
+**Presentation instructions**:
+
+- **Summary**: Show the issue title, type, status, priority, and assignee prominently
+- **Description**: Read `renderedFields.description` (HTML) and present as clean markdown. Extract acceptance criteria if present (look for headings, checklists, or "Acceptance Criteria" sections)
+- **Subtasks**: If `fields.subtasks` is non-empty, list each with key, summary, and status
+- **Links**: If `fields.issuelinks` is non-empty, list linked issues grouped by link type (e.g. "blocks", "is blocked by", "relates to")
+- **Parent**: If `fields.parent` exists, mention the parent epic/story
+- **Comments**: Show the last 3 comments from `fields.comment.comments` (sorted newest first). For each, show author display name, date, and body
+- **Never dump raw JSON** unless the user explicitly asks for it
+
+## 4. Read Jira Issue Comments
+
+Use when more comments are needed beyond what the issue endpoint returned, or when the user asks specifically for comment history.
+
+```bash
+curl -s --connect-timeout 10 --max-time 30 \
+  -H "Authorization: Basic $(printf '%s:%s' "$ATLASSIAN_EMAIL" "$ATLASSIAN_JIRA_READ_ONLY_TOKEN" | base64)" \
+  -H "Accept: application/json" \
+  "https://api.atlassian.com/ex/jira/${ATLASSIAN_CLOUD_ID}/rest/api/3/issue/{{TICKET_ID}}/comment?orderBy=-created&maxResults=10" | jq .
+```
+
+Replace `{{TICKET_ID}}` with the issue key.
+
+**Presentation instructions**:
+
+- Show each comment with: author display name, created date, and body text
+- The body is in Atlassian Document Format (ADF) — read the `content` nodes and render as markdown
+- If there are more comments than returned, mention the total count from the response
+
+## 5. Search Jira (JQL)
+
+Use when the user asks about sprint contents, epic children, text search across issues, or any bulk issue query.
+
+```bash
+curl -s --connect-timeout 10 --max-time 30 -G \
+  -H "Authorization: Basic $(printf '%s:%s' "$ATLASSIAN_EMAIL" "$ATLASSIAN_JIRA_READ_ONLY_TOKEN" | base64)" \
+  -H "Accept: application/json" \
+  --data-urlencode "jql={{JQL}}" \
+  "https://api.atlassian.com/ex/jira/${ATLASSIAN_CLOUD_ID}/rest/api/3/search?maxResults=20&fields=summary,status,issuetype,priority,assignee,parent" | jq .
+```
+
+Replace `{{JQL}}` with the user's query. URL-encode special characters.
+
+**Common JQL patterns** (suggest these to the user when relevant):
+
+| Use case                 | JQL                                                              |
+| ------------------------ | ---------------------------------------------------------------- |
+| Active sprint issues     | `project = {{PROJECT}} AND sprint in openSprints()`              |
+| Epic children (next-gen) | `parent = {{EPIC_KEY}}`                                          |
+| Epic children (classic)  | `"Epic Link" = {{EPIC_KEY}}`                                     |
+| Full text search         | `text ~ "{{SEARCH_TERM}}"`                                       |
+| Linked issues            | `issuekey in linkedIssues({{TICKET_ID}})`                        |
+| My open issues           | `assignee = currentUser() AND resolution = Unresolved`           |
+| Recently updated         | `project = {{PROJECT}} AND updated >= -7d ORDER BY updated DESC` |
+
+**Presentation instructions**:
+
+- Present results as a table with columns: Key, Type, Summary, Status, Priority, Assignee
+- Include the parent epic key if present
+- Show the total result count (`total` field) and note if results were truncated
+
+## 6. Read Confluence Page
+
+Use when the user shares a Confluence URL or page ID, or when a Jira issue links to Confluence content.
+
+```bash
+curl -s --connect-timeout 10 --max-time 30 \
+  -H "Authorization: Basic $(printf '%s:%s' "$ATLASSIAN_EMAIL" "$ATLASSIAN_CONFLUENCE_READ_ONLY_TOKEN" | base64)" \
+  -H "Accept: application/json" \
+  "https://api.atlassian.com/ex/confluence/${ATLASSIAN_CLOUD_ID}/rest/api/content/{{PAGE_ID}}?expand=body.storage,version,space,ancestors" | jq .
+```
+
+Replace `{{PAGE_ID}}` with the numeric page ID.
+
+**Extracting the page ID from a Confluence URL**:
+
+- URL format: `https://domain.atlassian.net/wiki/spaces/SPACE/pages/123456789/Page+Title` → page ID is `123456789`
+- URL format: `https://domain.atlassian.net/wiki/x/AbCdEf` → this is a tiny URL; fetch it and extract the page ID from the redirect or resolved content
+
+**Presentation instructions**:
+
+- Show: page title, space name, version number, last modified info
+- Show breadcrumb path from `ancestors` array (top-level → parent → current page)
+- The `body.storage.value` field contains HTML — read it and convert to clean markdown in your response
+- For large pages, summarize the key sections relevant to the user's current task rather than reproducing the entire page
+- If the page contains tables, preserve table formatting
+
+## 7. Search Confluence (CQL)
+
+Use when the user wants to find Confluence pages by keyword, label, or space.
+
+```bash
+curl -s --connect-timeout 10 --max-time 30 -G \
+  -H "Authorization: Basic $(printf '%s:%s' "$ATLASSIAN_EMAIL" "$ATLASSIAN_CONFLUENCE_READ_ONLY_TOKEN" | base64)" \
+  -H "Accept: application/json" \
+  --data-urlencode "cql={{CQL}}" \
+  "https://api.atlassian.com/ex/confluence/${ATLASSIAN_CLOUD_ID}/rest/api/content/search?limit=10" | jq .
+```
+
+Replace `{{CQL}}` with the query. URL-encode special characters.
+
+**Common CQL patterns**:
+
+| Use case             | CQL                                                        |
+| -------------------- | ---------------------------------------------------------- |
+| Text search          | `text ~ "{{SEARCH_TERM}}"`                                 |
+| Space + text         | `space = "{{SPACE_KEY}}" AND text ~ "{{SEARCH_TERM}}"`     |
+| Label filter         | `label = "{{LABEL}}"`                                      |
+| Space + label        | `space = "{{SPACE_KEY}}" AND label = "{{LABEL}}"`          |
+| Pages under ancestor | `ancestor = {{PAGE_ID}}`                                   |
+| Recently modified    | `lastModified >= "2024-01-01" AND space = "{{SPACE_KEY}}"` |
+
+**Presentation instructions**:
+
+- List results with: title, space name, last modified date, and a brief excerpt if available
+- Show total result count and note if truncated
+
+## 8. Confluence Child Pages
+
+Use when the user wants to see subpages under a Confluence page, or when exploring a documentation tree.
+
+```bash
+curl -s --connect-timeout 10 --max-time 30 \
+  -H "Authorization: Basic $(printf '%s:%s' "$ATLASSIAN_EMAIL" "$ATLASSIAN_CONFLUENCE_READ_ONLY_TOKEN" | base64)" \
+  -H "Accept: application/json" \
+  "https://api.atlassian.com/ex/confluence/${ATLASSIAN_CLOUD_ID}/rest/api/content/{{PAGE_ID}}/child/page?limit=25&expand=version" | jq .
+```
+
+Replace `{{PAGE_ID}}` with the parent page ID.
+
+**Presentation instructions**:
+
+- List child pages with: title, page ID, version number, and last modified date
+- If there are many children, present as a numbered list
+
+## 9. Boards and Sprints
+
+Use when the user asks about sprint status, board configuration, or wants to see what's in the current sprint.
+
+### List Boards
+
+```bash
+curl -s --connect-timeout 10 --max-time 30 \
+  -H "Authorization: Basic $(printf '%s:%s' "$ATLASSIAN_EMAIL" "$ATLASSIAN_JIRA_READ_ONLY_TOKEN" | base64)" \
+  -H "Accept: application/json" \
+  "https://api.atlassian.com/ex/jira/${ATLASSIAN_CLOUD_ID}/rest/agile/1.0/board?projectKeyOrId={{PROJECT_KEY}}" | jq .
+```
+
+Replace `{{PROJECT_KEY}}` with the project key (e.g. `PROJ`).
+
+### Get Active Sprint
+
+```bash
+curl -s --connect-timeout 10 --max-time 30 \
+  -H "Authorization: Basic $(printf '%s:%s' "$ATLASSIAN_EMAIL" "$ATLASSIAN_JIRA_READ_ONLY_TOKEN" | base64)" \
+  -H "Accept: application/json" \
+  "https://api.atlassian.com/ex/jira/${ATLASSIAN_CLOUD_ID}/rest/agile/1.0/board/{{BOARD_ID}}/sprint?state=active" | jq .
+```
+
+Replace `{{BOARD_ID}}` with the board ID from the previous call.
+
+### Get Sprint Issues
+
+```bash
+curl -s --connect-timeout 10 --max-time 30 \
+  -H "Authorization: Basic $(printf '%s:%s' "$ATLASSIAN_EMAIL" "$ATLASSIAN_JIRA_READ_ONLY_TOKEN" | base64)" \
+  -H "Accept: application/json" \
+  "https://api.atlassian.com/ex/jira/${ATLASSIAN_CLOUD_ID}/rest/agile/1.0/sprint/{{SPRINT_ID}}/issue?fields=summary,status,issuetype,priority,assignee" | jq .
+```
+
+Replace `{{SPRINT_ID}}` with the sprint ID from the previous call.
+
+**Workflow**: To answer "what's in the current sprint?", chain the three calls: list boards → get active sprint → get sprint issues.
+
+**Presentation instructions**:
+
+- Show sprint name, goal (if set), start/end dates, and state
+- Present sprint issues as a table: Key, Type, Summary, Status, Priority, Assignee
+- Group by status if helpful (To Do, In Progress, Done)
+
+## 10. Context Budget Guidance
+
+**Always summarize — never dump raw JSON** unless explicitly asked.
+
+- **Jira issues**: Lead with status, summary, and assignee. Show description as markdown. Append subtasks and links only if present.
+- **Confluence pages**: Convert HTML body to markdown. For large pages (>2000 words), summarize sections relevant to the user's current task and offer to read specific sections in detail.
+- **Sprint boards**: Present as a status-grouped table. Include completion counts (e.g. "12 of 20 issues done").
+- **Search results**: Present as a compact table. Never expand every result — list summaries and let the user pick which to read in full.
+- **Comments**: Show the 3 most recent unless the user asks for more.
+
+## 11. Error Handling
+
+| HTTP Status      | Meaning                                               | Fix                                                                                                                                                                                                                                            |
+| ---------------- | ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 401 Unauthorized | Invalid or expired API token                          | Ask user to verify the relevant token (`ATLASSIAN_JIRA_READ_ONLY_TOKEN` or `ATLASSIAN_CONFLUENCE_READ_ONLY_TOKEN`). Tokens can be regenerated at [Atlassian API tokens](https://id.atlassian.com/manage-profile/security/api-tokens).          |
+| 403 Forbidden    | Token is valid but lacks permission for this resource | Check that the scoped token has the correct **read** scope for the product. The Jira token needs `read:jira-work` scope; the Confluence token needs `read:confluence-content.all` scope. Also verify the user has access to the project/space. |
+| 404 Not Found    | Issue, page, or resource does not exist               | Verify the ticket ID, page ID, or URL. Check for typos. The resource may have been deleted or moved.                                                                                                                                           |
+
+**Never expose tokens**: Do not echo, log, or include token values in output when debugging authentication failures. Refer to tokens by variable name only.
+
+**Wrong token for wrong product**: If a Jira call returns 401 but the token is valid, check that you're using `ATLASSIAN_JIRA_READ_ONLY_TOKEN` (not the Confluence token) and vice versa.
+
+**Missing environment variable detection**: If a curl command returns a connection error or malformed URL, check whether `ATLASSIAN_CLOUD_ID`, `ATLASSIAN_EMAIL`, `ATLASSIAN_JIRA_READ_ONLY_TOKEN`, or `ATLASSIAN_CONFLUENCE_READ_ONLY_TOKEN` is unset and ask the user to set them (see Section 1).
+
+**Rate limiting**: Atlassian Cloud APIs have rate limits. If you receive a 429 response, wait a moment before retrying. For batch operations, add a small delay between requests.


### PR DESCRIPTION
## 🎟️ Tracking

## 📔 Objective

I created the skill a few weeks back, have been using it with success and it's time to share it. The skill needs with four (4) environment variables to make Atlassian API calls. The skill has instructions to guide Claude Code into making safe, valid API calls with proper exception handling returning meaningful information to the user. The skill keeps Claude Code focused on the minimal instructions necessary to retrieve the information and get to work.

### Why not the Atlassian MCP?

1. I do not like that that Atlassian MCP server needs such a heavy-handed read-write token. I don't want Claude Code to ever mutate Atlassian data on my-behalf. I think least privilege skills are superior for now. 
2. I didn't love have the Atlassian MCP server running in a Docker container just to make simple API calls (I know the space has evolved rapidly since the MCP first came out in Sept/October and you can run it differently now). Claude would spin up as many containers as it could especially with multi-agent steps.
3. Tools like the Atlassian MCP are well-know to devour tokens thus shrinking windows for Claude to focus on what's most important; helping us to create awesome code. Just look at how Anthropic noted that tooling can consume up to 50,000 tokens before the agent reads the request 🤮 [Advance Tool Use](https://www.anthropic.com/engineering/advanced-tool-use). 

### Why choose a Skill over an Agent or command?

1. Natural integration into workflow is key here because I am prompting Claude Code to continually ground itself in the particular Jira items that I have been working. I want a seamless; natural language to tell Claude to search Confluence for a topic while considering a specific Architecture Idea or Epic. I also don't want to be constrained by the explicit invocation of the slash command nor agents.
2. Skills execute in the current context window; no background agent or context. When I tell Claude to review a PR or review local changes that are linked to a Jira ticket, I want Claude to use the Atlassian information in the main context.
4. A skill can be narrowly scoped (read‑only Jira/Confluence) and easier to audit for least‑privilege access. Agents often accumulate broader powers.
5. Skills are targeted behaviors that keep Claude Code focused. We all know how difficult it can be to keep multi-step agents focused (think how challenging code review agents are).

