### PR TITLE
Implement minor changes to the atlassian-reader plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -37,7 +37,7 @@
     {
       "name": "atlassian-reader",
       "source": "./plugins/atlassian-reader",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "description": "Read-only access to Jira issues, epics, sprints, boards, and Confluence pages from Atlassian Cloud."
     }
   ]

--- a/plugins/atlassian-reader/.claude-plugin/plugin.json
+++ b/plugins/atlassian-reader/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atlassian-reader",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Read-only access to Jira issues, epics, sprints, boards, and Confluence pages from Atlassian Cloud.",
   "author": {
     "name": "Bitwarden",

--- a/plugins/atlassian-reader/CHANGELOG.md
+++ b/plugins/atlassian-reader/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to the Atlassian Reader Plugin will be documented in this fi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2026-02-10
+
+### Fixed
+
+- **JQL Search endpoint migration**: Updated from removed `/rest/api/3/search` to `/rest/api/3/search/jql` per Atlassian [CHANGE-2046](https://developer.atlassian.com/changelog/#CHANGE-2046)
+- **Pagination guidance**: Updated Section 5 to use cursor-based `isLast` field instead of legacy `total` for the new search endpoint
+
+### Added
+
+- **Acceptance Criteria field**: Issue reads now fetch `customfield_10192` (Bitwarden's A/C field) and presentation instructions prioritize it over description-embedded A/C
+- **Epic children discovery**: Section 3 now instructs agents to perform a JQL `parent =` search when reading Epics/Features, since next-gen projects don't populate `subtasks`
+- **API deprecation error handling**: Section 11 error table now covers `200 with errorMessages` responses for removed/deprecated endpoints
+
 ## [1.0.0] - 2026-02-09
 
 ### Added


### PR DESCRIPTION
## 🎟️ Tracking

## 📔 Objective

Fix Atlassian API errors that were being swallowed by Claude (probably because I was usually running it as a background agent and the agent just figured it out on its down). However, now these fixes work well in the main context window. 

Also, worked with Claude to ensure we added specific notes about which field in the response is our Jira Acceptance Criteria field.  Claude is now pulling that field into context using the skill and, without prompting, Claude knows just how important it is to its work. 