### PR TITLE
Cross-reference skills in plugins

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,43 +13,43 @@
     {
       "name": "claude-retrospective",
       "source": "./plugins/claude-retrospective",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "description": "Comprehensive analysis of Claude Code sessions to identify successful patterns, problematic areas, and opportunities for improvement."
     },
     {
       "name": "claude-config-validator",
       "source": "./plugins/claude-config-validator",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "description": "Validates Claude Code configuration files for security, structure, and quality. Reviews CLAUDE.md, skills, agents, prompts, commands, and settings."
     },
     {
       "name": "bitwarden-code-review",
       "source": "./plugins/bitwarden-code-review",
-      "version": "1.7.1",
+      "version": "1.8.0",
       "description": "Comprehensive code review system with organization-wide standards."
     },
     {
       "name": "bitwarden-init",
       "source": "./plugins/bitwarden-init",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "description": "Initialize Claude Code configuration with Bitwarden's standardized template format"
     },
     {
       "name": "bitwarden-software-engineer",
       "source": "./plugins/bitwarden-software-engineer",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "description": "Full-stack software engineering assistant with skills for Bitwarden client, server, and database development patterns."
     },
     {
       "name": "atlassian-reader",
       "source": "./plugins/atlassian-reader",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "description": "Read-only access to Jira issues, epics, sprints, boards, and Confluence pages from Atlassian Cloud."
     },
     {
       "name": "bitwarden-security-engineer",
       "source": "./plugins/bitwarden-security-engineer",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "description": "Application security engineering assistant for vulnerability triage, threat modeling, and secure code analysis."
     }
   ]

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ A curated collection of plugins for AI-assisted development at Bitwarden. Enable
 
 | Plugin                                                              | Version | Description                                                                                        |
 | ------------------------------------------------------------------- | ------- | -------------------------------------------------------------------------------------------------- |
-| [atlassian-reader](plugins/atlassian-reader/)                       | 1.1.0   | Read-only access to Jira issues, epics, sprints, boards, and Confluence pages from Atlassian Cloud |
-| [bitwarden-code-review](plugins/bitwarden-code-review/)             | 1.7.1   | Autonomous code review agent following Bitwarden engineering standards with GitHub integration     |
-| [bitwarden-init](plugins/bitwarden-init/)                           | 1.0.0   | Initialize and enhance CLAUDE.md files with Bitwarden's standardized template format               |
-| [bitwarden-security-engineer](plugins/bitwarden-security-engineer/) | 0.1.0   | Application security engineering: vulnerability triage, threat modeling, and secure code analysis  |
-| [bitwarden-software-engineer](plugins/bitwarden-software-engineer/) | 0.2.0   | Full-stack engineering assistant for Bitwarden client, server, and database development patterns   |
-| [claude-config-validator](plugins/claude-config-validator/)         | 1.0.0   | Validates Claude Code configuration files for security, structure, and quality                     |
-| [claude-retrospective](plugins/claude-retrospective/)               | 1.0.0   | Analyze Claude Code sessions to identify successful patterns and improvement opportunities         |
+| [atlassian-reader](plugins/atlassian-reader/)                       | 1.2.0   | Read-only access to Jira issues, epics, sprints, boards, and Confluence pages from Atlassian Cloud |
+| [bitwarden-code-review](plugins/bitwarden-code-review/)             | 1.8.0   | Autonomous code review agent following Bitwarden engineering standards with GitHub integration     |
+| [bitwarden-init](plugins/bitwarden-init/)                           | 1.1.0   | Initialize and enhance CLAUDE.md files with Bitwarden's standardized template format               |
+| [bitwarden-security-engineer](plugins/bitwarden-security-engineer/) | 0.2.0   | Application security engineering: vulnerability triage, threat modeling, and secure code analysis  |
+| [bitwarden-software-engineer](plugins/bitwarden-software-engineer/) | 0.3.0   | Full-stack engineering assistant for Bitwarden client, server, and database development patterns   |
+| [claude-config-validator](plugins/claude-config-validator/)         | 1.1.0   | Validates Claude Code configuration files for security, structure, and quality                     |
+| [claude-retrospective](plugins/claude-retrospective/)               | 1.1.0   | Analyze Claude Code sessions to identify successful patterns and improvement opportunities         |
 
 ## Usage
 

--- a/plugins/atlassian-reader/.claude-plugin/plugin.json
+++ b/plugins/atlassian-reader/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atlassian-reader",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Read-only access to Jira issues, epics, sprints, boards, and Confluence pages from Atlassian Cloud.",
   "author": {
     "name": "Bitwarden",

--- a/plugins/atlassian-reader/CHANGELOG.md
+++ b/plugins/atlassian-reader/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Atlassian Reader Plugin will be documented in this fi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2026-02-23
+
+### Added
+
+- Cross-plugin skill awareness: skill now suggests invoking security engineer `bitwarden-security-context` for security-tagged tickets and software engineer skills for validating technical specs against Bitwarden conventions when sibling plugins are installed
+
 ## [1.1.0] - 2026-02-10
 
 ### Fixed

--- a/plugins/atlassian-reader/skills/atlassian-reader/SKILL.md
+++ b/plugins/atlassian-reader/skills/atlassian-reader/SKILL.md
@@ -269,3 +269,17 @@ Replace `{{SPRINT_ID}}` with the sprint ID from the previous call.
 **Missing environment variable detection**: If a curl command returns a connection error or malformed URL, check whether `ATLASSIAN_CLOUD_ID`, `ATLASSIAN_EMAIL`, `ATLASSIAN_JIRA_READ_ONLY_TOKEN`, or `ATLASSIAN_CONFLUENCE_READ_ONLY_TOKEN` is unset and ask the user to set them (see Section 1).
 
 **Rate limiting**: Atlassian Cloud APIs have rate limits. If you receive a 429 response, wait a moment before retrying. For batch operations, add a small delay between requests.
+
+## 12. Cross-Plugin Enrichment
+
+After reading Jira or Confluence content, sibling plugin skills can provide deeper analysis:
+
+### Security Context (bitwarden-security-engineer plugin)
+
+- **Security-tagged tickets** → when a Jira issue has security labels, components, or mentions vulnerabilities, activate `Skill(bitwarden-security-context)` to provide Bitwarden's security principles and vocabulary for interpreting the issue's security requirements
+
+### Development Context (bitwarden-software-engineer plugin)
+
+- **Technical specs or architecture docs** → when reading Confluence pages with technical specifications, note that `Skill(writing-server-code)`, `Skill(writing-client-code)`, and `Skill(writing-database-queries)` can validate whether specifications align with Bitwarden's actual development conventions
+
+These skills are optional. If unavailable, present the raw Atlassian content without additional analysis.

--- a/plugins/bitwarden-code-review/.claude-plugin/plugin.json
+++ b/plugins/bitwarden-code-review/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bitwarden-code-review",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "description": "Comprehensive code review system with organization-wide standards.",
   "author": {
     "name": "Bitwarden",

--- a/plugins/bitwarden-code-review/CHANGELOG.md
+++ b/plugins/bitwarden-code-review/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Bitwarden Code Review Plugin will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.0] - 2026-02-23
+
+### Added
+
+- Cross-plugin skill awareness: agent now invokes security engineer skills (`analyzing-code-security`, `reviewing-security-architecture`, `reviewing-dependencies`) for security-sensitive PRs and software engineer skills (`writing-server-code`, `writing-client-code`, `writing-database-queries`) for convention validation when sibling plugins are installed
+
 ## [1.7.1] - 2026-01-19
 
 ### Changed

--- a/plugins/bitwarden-code-review/agents/bitwarden-code-reviewer/AGENT.md
+++ b/plugins/bitwarden-code-review/agents/bitwarden-code-reviewer/AGENT.md
@@ -1,6 +1,6 @@
 ---
 name: bitwarden-code-reviewer
-version: 1.7.1
+version: 1.8.0
 description: Conducts thorough code reviews following Bitwarden standards. Finds all issues first pass, avoids false positives, respects codebase conventions. Invoke when user mentions "code review", "review code", "review", "PR", or "pull request".
 model: opus
 skills: avoiding-false-positives, classifying-review-findings, posting-bitwarden-review-comments, posting-review-summary, reviewing-incremental-changes
@@ -165,6 +165,28 @@ Invoke these skills in order:
 
 - **Review code, not developers** - Frame findings as improvement opportunities
 - **Maintain professional tone** - Be constructive and collaborative
+
+## Cross-Plugin Enrichment
+
+When sibling Bitwarden plugins are installed, specialist skills improve review quality:
+
+### Security-Enhanced Review (bitwarden-security-engineer plugin)
+
+For security-sensitive changes (auth, crypto, access control, user input handling):
+
+- **Potential vulnerabilities** → activate `Skill(analyzing-code-security)` to validate findings against OWASP/CWE checklists with Bitwarden-specific vulnerability patterns
+- **Auth/encryption/trust-boundary changes** → activate `Skill(reviewing-security-architecture)` to verify patterns match approved approaches
+- **Dependency updates** → activate `Skill(reviewing-dependencies)` to assess supply chain risk
+
+### Convention-Aware Review (bitwarden-software-engineer plugin)
+
+For implementation pattern review:
+
+- **C#/.NET server changes** → activate `Skill(writing-server-code)` to verify CQS patterns, `TryAdd*` DI, nullable reference types, `Async` suffix conventions
+- **Angular/TypeScript client changes** → activate `Skill(writing-client-code)` to verify `tw-` prefix, `inject()` usage, standalone components, signal vs RxJS patterns
+- **Database changes** → activate `Skill(writing-database-queries)` to verify dual-ORM parity, migration naming, and EDD phasing
+
+These skills are optional. If unavailable, apply existing review knowledge.
 
 ## Completion
 

--- a/plugins/bitwarden-init/.claude-plugin/plugin.json
+++ b/plugins/bitwarden-init/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bitwarden-init",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Initialize Claude Code configuration with Bitwarden's standardized template format",
   "author": {
     "name": "Bitwarden",
@@ -8,15 +8,6 @@
   },
   "homepage": "https://github.com/bitwarden/ai-plugins/tree/main/plugins/bitwarden-init",
   "repository": "https://github.com/bitwarden/ai-plugins",
-  "keywords": [
-    "init",
-    "initialization",
-    "setup",
-    "configuration",
-    "template"
-  ],
-  "commands": [
-    "./commands/init/init.md",
-    "./commands/enhance/enhance.md"
-  ]
+  "keywords": ["init", "initialization", "setup", "configuration", "template"],
+  "commands": ["./commands/init/init.md", "./commands/enhance/enhance.md"]
 }

--- a/plugins/bitwarden-init/CHANGELOG.md
+++ b/plugins/bitwarden-init/CHANGELOG.md
@@ -5,9 +5,16 @@ All notable changes to the Bitwarden Init plugin will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2026-02-23
+
+### Added
+
+- Post-generation validation in `/enhance` command: invokes config validator `reviewing-claude-config` and security engineer `detecting-secrets` skills to validate generated CLAUDE.md files when sibling plugins are installed
+
 ## [1.0.0] - 2026-01-14
 
 ### Added
+
 - Initial release of bitwarden-init plugin
 - `/bitwarden-init:init` command that chains Anthropic's `/init` with Bitwarden enhancement
 - `/bitwarden-init:enhance` command for enhancing existing CLAUDE.md files

--- a/plugins/bitwarden-init/CONTRIBUTING.md
+++ b/plugins/bitwarden-init/CONTRIBUTING.md
@@ -19,9 +19,11 @@ When making ANY changes to the plugin (code, documentation, configuration, scrip
    - PATCH (0.0.X): Bug fixes, documentation updates, security patches
 
 2. **Use the version bump script** from the repository root:
+
    ```bash
    ./scripts/bump-plugin-version.sh bitwarden-init <new-version>
    ```
+
    This automatically updates all required files including `.claude-plugin/plugin.json`
 
 3. **Add an entry to `CHANGELOG.md`** following [Keep a Changelog](https://keepachangelog.com/) format
@@ -35,6 +37,7 @@ claude --plugin-dir /path/to/bitwarden-ai-plugins/plugins/bitwarden-init
 ```
 
 Test both commands:
+
 - `/bitwarden-init:init` - Verify it runs both phases and generates a complete CLAUDE.md
 - `/bitwarden-init:enhance` - Verify it enhances an existing CLAUDE.md with the template structure
 

--- a/plugins/bitwarden-init/README.md
+++ b/plugins/bitwarden-init/README.md
@@ -22,6 +22,7 @@ Restart Claude Code after installation.
 ### `/bitwarden-init:init`
 
 Generates a new CLAUDE.md file. Runs both phases automatically:
+
 1. Anthropic's `/init` analyzes the codebase
 2. `/enhance` restructures and extends the output
 

--- a/plugins/bitwarden-init/commands/enhance/enhance.md
+++ b/plugins/bitwarden-init/commands/enhance/enhance.md
@@ -24,6 +24,7 @@ Enhance the existing CLAUDE.md file with Bitwarden's standardized template forma
 3. **Enhance CLAUDE.md**: Restructure the file to use **exactly** the following sections.
 
 **CRITICAL REQUIREMENTS:**
+
 - The final CLAUDE.md MUST use these exact headings verbatim - no other top-level headings are allowed
 - ALL content from the original CLAUDE.md MUST be incorporated into one of these sections - do not remove any information
 - Reorganize and merge existing content into the appropriate sections below
@@ -32,6 +33,7 @@ Enhance the existing CLAUDE.md file with Bitwarden's standardized template forma
 ---
 
 **Required Sections (use these exact headings):**
+
 # [Project Name] - Claude Code Configuration
 
 Brief description of the project and its primary purpose.
@@ -39,11 +41,13 @@ Brief description of the project and its primary purpose.
 ## Overview
 
 ### What This Project Does
+
 - Primary function/purpose (1-2 sentences)
 - Key interfaces or entry points
 - Target users/consumers
 
 ### Key Concepts
+
 - Domain-specific terminology
 - Important abstractions to understand
 
@@ -80,6 +84,7 @@ src/
 ```
 
 ### Key Principles
+
 1. **Principle One**: Brief explanation
 2. **Principle Two**: Brief explanation
 3. **Principle Three**: Brief explanation
@@ -91,11 +96,13 @@ src/
 **Purpose**: Why this pattern exists
 
 **Implementation**:
+
 ```typescript
 // Code example showing the canonical implementation
 ```
 
 **Usage**:
+
 ```typescript
 // Code example showing how to use the pattern
 ```
@@ -109,31 +116,37 @@ src/
 Step-by-step checklist for the most common development task.
 
 **1. Define the Schema** (`src/schemas/[domain].ts`)
+
 ```typescript
 // Template code
 ```
 
 **2. Define the [Entity]** (`src/[entities]/[domain].ts`)
+
 ```typescript
 // Template code
 ```
 
 **3. Implement the Handler** (`src/handlers/[domain].ts`)
+
 ```typescript
 // Template code
 ```
 
 **4. Register the Handler** (`src/index.ts`)
+
 ```typescript
 // Where and how to register
 ```
 
 **5. Write Tests** (`tests/[domain].spec.ts`)
+
 ```typescript
 // Test template
 ```
 
 **6. Update Documentation**
+
 - Files that may need updates
 
 ### Common Patterns
@@ -197,15 +210,15 @@ const exampleSchema = z.object({
 
 ### Security Functions
 
-| Function | Purpose | Usage |
-|----------|---------|-------|
+| Function         | Purpose      | Usage          |
+| ---------------- | ------------ | -------------- |
 | `functionName()` | What it does | When to use it |
 
 ### Environment Configuration
 
-| Variable | Required | Description | Example |
-|----------|----------|-------------|---------|
-| `VAR_NAME` | Yes/No | What it configures | `example-value` |
+| Variable   | Required | Description        | Example         |
+| ---------- | -------- | ------------------ | --------------- |
+| `VAR_NAME` | Yes/No   | What it configures | `example-value` |
 
 ### Authentication & Authorization
 
@@ -229,9 +242,10 @@ tests/
 ### Writing Tests
 
 **Unit Test Template**:
+
 ```typescript
-describe('[Feature]', () => {
-  it('should [expected behavior]', () => {
+describe("[Feature]", () => {
+  it("should [expected behavior]", () => {
     // Arrange
     // Act
     // Assert
@@ -240,8 +254,9 @@ describe('[Feature]', () => {
 ```
 
 **Integration Test Template**:
+
 ```typescript
-describe('[Feature] Integration', () => {
+describe("[Feature] Integration", () => {
   // Setup/teardown
   // Test cases
 });
@@ -266,23 +281,28 @@ npm test -- [file]    # Run specific file
 ## Code Style & Standards
 
 ### Formatting
+
 - Tool used (Prettier, etc.)
 - Key configuration
 
 ### Naming Conventions
+
 - `camelCase` for: variables, functions
 - `PascalCase` for: types, interfaces, classes
 - `SCREAMING_SNAKE_CASE` for: constants
 
 ### Imports
+
 - Ordering rules
 - Extension requirements (e.g., `.js` for ES modules)
 
 ### Comments
+
 - When to use JSDoc
 - When to use inline comments
 
 ### Pre-commit Hooks
+
 - What runs automatically
 - Manual checks to run
 
@@ -322,6 +342,7 @@ npm run build
 ### Versioning
 
 Follow semantic versioning: `MAJOR.MINOR.PATCH`
+
 - `MAJOR`: Breaking changes
 - `MINOR`: New features (backwards compatible)
 - `PATCH`: Bug fixes
@@ -360,19 +381,23 @@ Follow semantic versioning: `MAJOR.MINOR.PATCH`
 ## References
 
 ### Official Documentation
+
 - [Link to primary docs]()
 - [Link to API reference]()
 
 ### Internal Documentation
+
 - [Link to contributing guide]()
 - [Link to code style guide]()
 
 ### Tools & Libraries
+
 - [Link to key dependency docs]()
 
 ---
 
 **Enhancement Guidelines:**
+
 - **No information loss**: Every piece of content from the original CLAUDE.md must appear in the final output, incorporated into the appropriate section
 - **Strict heading structure**: Only the headings above are permitted as top-level sections (## level) - merge any other headings as subsections (### level) or bullet points within the appropriate section
 - **Fill gaps**: Add information for any sections that are missing or incomplete based on your supplementary research
@@ -383,6 +408,7 @@ Follow semantic versioning: `MAJOR.MINOR.PATCH`
 - **Stay current**: Reference actual patterns found in the code, not assumptions
 
 **Content Quality Standards:**
+
 - Every section should have substantive, codebase-specific content
 - Avoid generic advice that could apply to any project
 - Include file paths and specific examples (e.g., "See `src/auth/guards/` for authentication guards")
@@ -391,7 +417,22 @@ Follow semantic versioning: `MAJOR.MINOR.PATCH`
 - Note any deviations from standard practices and why they exist
 
 **Handling Optional Sections:**
+
 - If a section is not applicable to this project (e.g., "Deployment" for a library), include the heading with a brief note: "Not applicable - this is a library consumed as a dependency."
 - Never omit a required heading entirely
 
 **Final Step**: After enhancing CLAUDE.md, provide a detailed summary of what was added or changed compared to the original file.
+
+## Post-Generation Validation
+
+After enhancing the CLAUDE.md file, run available validation:
+
+### Config Validation (claude-config-validator plugin)
+
+- **Validate the generated CLAUDE.md** → activate `Skill(reviewing-claude-config)` to verify the generated file has no hardcoded secrets in code examples, proper structure, valid file references, and follows progressive disclosure patterns
+
+### Security Scan (bitwarden-security-engineer plugin)
+
+- **Scan code examples for secrets** → activate `Skill(detecting-secrets)` to ensure no credentials appear in the documentation's code snippets
+
+These validation steps are optional. If the plugins are not installed, skip validation.

--- a/plugins/bitwarden-init/commands/init/init.md
+++ b/plugins/bitwarden-init/commands/init/init.md
@@ -10,6 +10,7 @@ Initialize Claude Code configuration for this repository using a two-phase proce
 First, execute the built-in `/init` command to generate an initial CLAUDE.md file:
 
 Use the Bash tool to run:
+
 ```bash
 claude -p "/init" --allowedTools "Read" "Write" "WebFetch" "Grep" "Glob" --model "opus"
 ```
@@ -21,6 +22,7 @@ Wait for this to complete and verify that CLAUDE.md was created in the current d
 Once Phase 1 completes successfully, run the `/enhance` command from this plugin to extend the CLAUDE.md file with Bitwarden's standardized sections:
 
 Use the Bash tool to run:
+
 ```bash
 claude -p "/bitwarden-init:enhance" --allowedTools "Read" "Edit" "WebFetch" "Grep" "Glob" --model "opus"
 ```

--- a/plugins/bitwarden-security-engineer/.claude-plugin/plugin.json
+++ b/plugins/bitwarden-security-engineer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bitwarden-security-engineer",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Application security engineering assistant for vulnerability triage, threat modeling, and secure code analysis at Bitwarden.",
   "author": {
     "name": "Bitwarden",

--- a/plugins/bitwarden-security-engineer/CHANGELOG.md
+++ b/plugins/bitwarden-security-engineer/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the `bitwarden-security-engineer` plugin will be document
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2026-02-23
+
+### Added
+
+- `bitwarden-security-context` skill: lightweight quick-reference for security principles (P01-P06), vocabulary, and data classification standards
+- Cross-plugin skill awareness: agent now invokes software engineer skills (`writing-server-code`, `writing-database-queries`, `writing-client-code`) to ground remediation recommendations in Bitwarden's actual conventions when the `bitwarden-software-engineer` plugin is installed alongside
+
 ## [0.1.0] - 2026-02-12
 
 ### Added

--- a/plugins/bitwarden-security-engineer/agents/bitwarden-security-engineer.md
+++ b/plugins/bitwarden-security-engineer/agents/bitwarden-security-engineer.md
@@ -61,3 +61,13 @@ After completing security work, verify before declaring done:
 - Every finding maps to a specific CWE ID with evidence (code location + data flow)
 - CORRECT/WRONG examples provided for non-obvious fixes
 - Findings prioritized by practical exploitability, not just theoretical risk
+
+## Development-Aware Recommendations
+
+When the `bitwarden-software-engineer` plugin is installed, development context skills are available. Use them to ground security recommendations in Bitwarden's actual patterns:
+
+- **When recommending server-side fixes** → activate `Skill(writing-server-code)` to ensure recommendations use CQS pattern, `TryAdd*` DI, file-scoped namespaces, and `BitAutoData` for tests
+- **When recommending database fixes** → activate `Skill(writing-database-queries)` then `Skill(implementing-dapper-queries)` or `Skill(implementing-ef-core)` as appropriate, to ensure remediation follows Bitwarden's dual-ORM conventions
+- **When recommending client-side fixes** → activate `Skill(writing-client-code)` to ensure fixes use Angular conventions (no `innerHTML`, `tw-` prefix for Tailwind, proper `inject()` usage)
+
+These skills are optional — if unavailable, provide standard security recommendations.

--- a/plugins/bitwarden-security-engineer/skills/bitwarden-security-context/SKILL.md
+++ b/plugins/bitwarden-security-engineer/skills/bitwarden-security-context/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: bitwarden-security-context
+description: Bitwarden's security principles (P01-P06), security vocabulary, and data classification standards. Use when you need foundational security context for any Bitwarden development, review, or security task — such as understanding trust boundaries, data protection requirements, or Bitwarden-specific security terminology.
+---
+
+# Bitwarden Security Context
+
+Quick-reference for Bitwarden's foundational security framework. Use this for security context during development, code review, or security analysis without loading the full threat-modeling or architecture-review skills.
+
+## Security Principles (P01-P06)
+
+These six principles form the foundation for all security decisions at Bitwarden.
+
+| Principle | Name                                         | Core Guarantee                                                                                                                                                                                                                                       |
+| --------- | -------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **P01**   | Servers are Zero Knowledge                   | Bitwarden infrastructure cannot access unencrypted user data. The server must not enable weakening of user-chosen protections, masquerade server data as user-encrypted content, or access encrypted data outside the client context.                |
+| **P02**   | A Locked Vault is Secure                     | Highly sensitive vault data cannot be accessed in plaintext once the vault is locked, even if the device is compromised after locking. Platform limitations (e.g., JS memory) are mitigated through buffer clearing and available security features. |
+| **P03**   | Limited Security on Semi-Compromised Devices | For unlocked vaults on devices with userspace malware (but intact OS/kernel), clients maximize kernel/OS-level protections and balance security with usability through controls like biometrics.                                                     |
+| **P04**   | No Security on Fully Compromised Systems     | Bitwarden cannot guarantee vault protection when hardware or OS-level integrity is fully compromised. This applies to unlocked vaults only — locked vaults are covered by P02.                                                                       |
+| **P05**   | Controlled Access to Vault Data              | Vault data, whether at rest or in use, is accessible only to authorized parties under the user's explicit control. Isolation mechanisms are critical in high-risk environments like web browsers.                                                    |
+| **P06**   | Minimized Impact of Security Breaches        | Limit breach scope and duration through session invalidation, key rotation (countering "harvest now, decrypt later"), and post-compromise security (new data remains protected after a breach).                                                      |
+
+### Controlled Exceptions
+
+Principles have documented exceptions. Known examples:
+
+- **P01 — Key Connector**: Self-hosted SSO without passwords. The server holds encryption keys on behalf of the user.
+- **P01 — Icons Service**: Plaintext domain names are sent to retrieve favicons.
+
+Full documentation: [Security Principles](https://contributing.bitwarden.com/architecture/security/principles/)
+
+## Security Vocabulary
+
+Standard terminology for security discussions at Bitwarden.
+
+| Term                             | Definition                                                                                                                   |
+| -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| **Vault Data**                   | A user's private information stored in Bitwarden (passwords, usernames, secure notes, credit cards, identities, attachments) |
+| **Protected Data**               | Data stored in unreadable format (typically encrypted) with expectations about secure key storage                            |
+| **Data at Rest**                 | Stored data not actively used or transmitted (disk storage on devices or servers)                                            |
+| **Data in Use**                  | Data actively being processed or accessed, held in volatile memory                                                           |
+| **Data in Transit**              | Data actively transferred between locations, processes, or devices                                                           |
+| **Secure Channel**               | A communication channel providing confidentiality (unreadable to unauthorized parties) and integrity (tamper-proof)          |
+| **Trusted Channel**              | A secure channel that also provides authenticity (verified identities of communicating parties)                              |
+| **Data Exporting**               | Controlled process where data leaves Bitwarden unprotected, nullifying security guarantees. Requires informed consent.       |
+| **Data Sharing**                 | Controlled data exchange within the Bitwarden secure environment (security guarantees maintained)                            |
+| **Data Leaking**                 | Unintentional departure of data from Bitwarden unprotected                                                                   |
+| **Bitwarden Secure Environment** | Any process or application adhering to Bitwarden's security standards                                                        |
+
+Full documentation: [Security Definitions](https://contributing.bitwarden.com/architecture/security/definitions)
+
+## Security Requirements by Category
+
+| Category | Scope                 | Key Obligations                                                                                                                                     |
+| -------- | --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **VD**   | Vault Data            | Protected at rest (encrypted with UserKey), allowed in use (decrypted during unlock), trusted channels in transit, export requires informed consent |
+| **EK**   | Encryption Keys       | 256-bit security strength, protected at rest and in transit, must never be exported                                                                 |
+| **AT**   | Authentication Tokens | Protected storage at rest, mandatory transit protection                                                                                             |
+| **SC**   | Secure Channels       | Confidentiality, integrity, replay prevention, forward secrecy for long-lived channels                                                              |
+| **TC**   | Trusted Channels      | Secure channel properties plus receiver identity verification                                                                                       |
+
+Full documentation: [Security Requirements](https://contributing.bitwarden.com/architecture/security/requirements)

--- a/plugins/bitwarden-software-engineer/.claude-plugin/plugin.json
+++ b/plugins/bitwarden-software-engineer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bitwarden-software-engineer",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Comprehensive full-stack software engineering assistant proficient in modern software development at Bitwarden.",
   "author": {
     "name": "Bitwarden",
@@ -8,13 +8,6 @@
   },
   "homepage": "https://github.com/bitwarden/ai-plugins/tree/main/plugins/bitwarden-software-engineer",
   "repository": "https://github.com/bitwarden/ai-plugins",
-  "keywords": [
-    "typescript",
-    "csharp",
-    "sql",
-    "fullstack"
-  ],
-  "agents": [
-    "./agents/bitwarden-software-engineer.md"
-  ]
+  "keywords": ["typescript", "csharp", "sql", "fullstack"],
+  "agents": ["./agents/bitwarden-software-engineer.md"]
 }

--- a/plugins/bitwarden-software-engineer/CHANGELOG.md
+++ b/plugins/bitwarden-software-engineer/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the `bitwarden-software-engineer` plugin will be document
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-02-23
+
+### Added
+
+- Cross-plugin skill awareness: agent now proactively invokes security engineer skills (`reviewing-security-architecture`, `analyzing-code-security`, `reviewing-dependencies`, `detecting-secrets`) when the `bitwarden-security-engineer` plugin is installed alongside
+
 ## [0.2.0] - 2026-02-09
 
 ### Added

--- a/plugins/bitwarden-software-engineer/agents/bitwarden-software-engineer.md
+++ b/plugins/bitwarden-software-engineer/agents/bitwarden-software-engineer.md
@@ -50,3 +50,14 @@ After making changes, always verify your work before declaring done. Use the app
 ### Database changes
 
 - Verify your changes against the conventions in the active database skill (`implementing-dapper-queries`, `implementing-ef-core`, or `writing-database-queries`)
+
+## Security-Aware Development
+
+When the `bitwarden-security-engineer` plugin is installed, additional security skills are available. Use them proactively:
+
+- **Before implementing auth/crypto/access-control features** → activate `Skill(reviewing-security-architecture)` to verify your design against approved patterns (token handling, RBAC, encryption at rest/transit, trust boundaries)
+- **When handling user input that reaches SQL, HTML, file system, or URLs** → activate `Skill(analyzing-code-security)` to check for injection, XSS, SSRF, and path traversal against Bitwarden's vulnerability pattern library
+- **When adding or updating dependencies** → activate `Skill(reviewing-dependencies)` to assess supply chain risk before introducing new packages
+- **When working with secrets or configuration** → activate `Skill(detecting-secrets)` to verify no credentials are hardcoded
+
+These skills are optional — if unavailable (plugin not installed), proceed with your standard workflow.

--- a/plugins/bitwarden-software-engineer/skills/writing-client-code/SKILL.md
+++ b/plugins/bitwarden-software-engineer/skills/writing-client-code/SKILL.md
@@ -84,9 +84,9 @@ export class CryptoService {
 ```html
 <!-- CORRECT -->
 <div class="tw-flex tw-gap-2 tw-mt-4">
-
-<!-- WRONG — missing tw- prefix, will be stripped -->
-<div class="flex gap-2 mt-4">
+  <!-- WRONG — missing tw- prefix, will be stripped -->
+  <div class="flex gap-2 mt-4"></div>
+</div>
 ```
 
 ### Const objects over enums (ADR-0025)

--- a/plugins/claude-config-validator/.claude-plugin/plugin.json
+++ b/plugins/claude-config-validator/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-config-validator",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Validates Claude Code configuration files for security, structure, and quality. Reviews CLAUDE.md, skills, agents, prompts, commands, and settings with comprehensive validation checklists.",
   "author": {
     "name": "Bitwarden",

--- a/plugins/claude-config-validator/CHANGELOG.md
+++ b/plugins/claude-config-validator/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Claude Config Validator Plugin will be documented in 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2026-02-23
+
+### Added
+
+- Cross-plugin skill awareness in `reviewing-claude-config` skill: invokes security engineer `detecting-secrets` skill for enhanced context-aware secret detection when the `bitwarden-security-engineer` plugin is installed
+
 ## [1.0.0] - 2025-11-14
 
 ### Added

--- a/plugins/claude-config-validator/skills/reviewing-claude-config/SKILL.md
+++ b/plugins/claude-config-validator/skills/reviewing-claude-config/SKILL.md
@@ -156,6 +156,16 @@ Load the specific example relevant to your file type (on-demand only, not upfron
 - Settings → `examples/example-settings-review.md`
 - Prompts → `examples/example-prompts-review.md`
 
+## Cross-Plugin Enrichment
+
+### Enhanced Secret Detection (bitwarden-security-engineer plugin)
+
+When the `bitwarden-security-engineer` plugin is installed, supplement the manual security scan above with:
+
+- **Comprehensive secret patterns** → activate `Skill(detecting-secrets)` for context-aware detection that distinguishes test fixtures from production secrets, and covers patterns beyond the manual checks above (connection strings, private keys, cloud provider tokens)
+
+This skill is optional. If unavailable, rely on the manual security checks above.
+
 ## Core Principles
 
 - **Security first**: Always check for committed settings, secrets, overly broad permissions

--- a/plugins/claude-retrospective/.claude-plugin/plugin.json
+++ b/plugins/claude-retrospective/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-retrospective",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Comprehensive analysis of Claude Code sessions to identify successful patterns, problematic areas, and opportunities for improvement.",
   "author": {
     "name": "Bitwarden",

--- a/plugins/claude-retrospective/CHANGELOG.md
+++ b/plugins/claude-retrospective/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Claude Retrospective Plugin will be documented in thi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2026-02-23
+
+### Added
+
+- Cross-plugin skill awareness in `retrospecting` skill: invokes security engineer `detecting-secrets` and `analyzing-code-security` skills to flag security issues in session diffs, and code review `classifying-review-findings` to categorize changes by impact
+
 ## [1.0.0] - 2025-11-03
 
 ### Added

--- a/plugins/claude-retrospective/skills/retrospecting/SKILL.md
+++ b/plugins/claude-retrospective/skills/retrospecting/SKILL.md
@@ -391,6 +391,23 @@ If approaching context limit during analysis:
 - Create concise reports that highlight key insights prominently
 - Understand session context before analyzing effectiveness
 
+## Cross-Plugin Enrichment
+
+When sibling Bitwarden plugins are installed, retrospectives gain specialist analysis:
+
+### Security-Aware Retrospectives (bitwarden-security-engineer plugin)
+
+After collecting git diffs from the session:
+
+- **Scan for committed credentials** → activate `Skill(detecting-secrets)` against the session's git diffs to warn if secrets were inadvertently committed
+- **Assess security posture of new code** → if the session introduced auth, crypto, or input-handling code, activate `Skill(analyzing-code-security)` to flag potential vulnerabilities in the retrospective report
+
+### Quality Classification (bitwarden-code-review plugin)
+
+- **Classify session changes by impact** → activate `Skill(classifying-review-findings)` to categorize the session's changes using the CRITICAL/IMPORTANT/DEBT/SUGGESTED framework, giving users a clear picture of what needs attention
+
+These skills are optional. If unavailable, proceed with standard retrospective analysis.
+
 ## Success Criteria
 
 A good retrospective should:


### PR DESCRIPTION
## 🎟️ Tracking

Review of plugin usage and seeing skills gaps.

## 📔 Objective

I felt our plugins could benefit from the others and using their skills. After some analysis, we just need to tell them about each other.

3 agent system prompts updated (awareness sections added):

- Software engineer: "Security-Aware Development" section: proactively invokes `reviewing-security-architecture`, `analyzing-code-security`, `reviewing-dependencies`, `detecting-secrets`
- Security engineer: "Development-Aware Recommendations" section: invokes `writing-server-code`, `writing-database-queries`, `writing-client-code` to ground remediation in Bitwarden conventions
- Code reviewer: "Cross-Plugin Enrichment" section: invokes both security and software engineer skills for security-enhanced and convention-aware reviews

4 skill/command files updated (enrichment sections added):

- Retrospective: flags committed secrets and classifies session changes by impact
- Config validator: enhanced secret detection via detecting-secrets
- Init / enhance: post-generation validation via `reviewing-claude-config` and `detecting-secrets`
- Atlassian reader: contextual analysis for security-tagged tickets and technical specs

1 new skill created:

- `bitwarden-security-context`:  lightweight quick-reference (security principles P01-P06, vocabulary, data classification) accessible to any agent without loading the full threat-modeling skill

All-in we should see this pretty quickly in code reviews at a minimum.