### PR TITLE
Disabling Claude Code attribution settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,8 @@
 {
+  "attribution": {
+    "commit": "",
+    "pr": ""
+  },
   "permissions": {
     "deny": [
       "Bash(gh pr merge:*)",


### PR DESCRIPTION
## 🎟️ Tracking

## 📔 Objective

We do not want Claude attributions showing up in git or in pull-requests. 
Following Anthropic's best practices to disable it: [Claude Code Attribution settings](https://code.claude.com/docs/en/settings#attribution-settings).