### PR TITLE
Remove redundant skills field from plugin.json across all plugins

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,19 +13,19 @@
     {
       "name": "claude-retrospective",
       "source": "./plugins/claude-retrospective",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "description": "Comprehensive analysis of Claude Code sessions to identify successful patterns, problematic areas, and opportunities for improvement."
     },
     {
       "name": "claude-config-validator",
       "source": "./plugins/claude-config-validator",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "description": "Validates Claude Code configuration files for security, structure, and quality. Reviews CLAUDE.md, skills, agents, prompts, commands, and settings."
     },
     {
       "name": "bitwarden-code-review",
       "source": "./plugins/bitwarden-code-review",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "description": "Comprehensive code review system with organization-wide standards."
     },
     {
@@ -37,7 +37,7 @@
     {
       "name": "bitwarden-product-analyst",
       "source": "./plugins/bitwarden-product-analyst",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "description": "Product analyst agent for creating comprehensive Bitwarden requirements documents from multiple sources"
     },
     {
@@ -49,7 +49,7 @@
     {
       "name": "atlassian-reader",
       "source": "./plugins/atlassian-reader",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "description": "Read-only access to Jira issues, epics, sprints, boards, and Confluence pages from Atlassian Cloud."
     },
     {

--- a/README.md
+++ b/README.md
@@ -4,16 +4,17 @@ A curated collection of plugins for AI-assisted development at Bitwarden. Enable
 
 ## Available Plugins
 
-| Plugin                                                              | Version | Description                                                                                        |
-| ------------------------------------------------------------------- | ------- | -------------------------------------------------------------------------------------------------- |
-| [atlassian-reader](plugins/atlassian-reader/)                       | 1.2.0   | Read-only access to Jira issues, epics, sprints, boards, and Confluence pages from Atlassian Cloud |
-| [bitwarden-atlassian-tools](plugins/bitwarden-atlassian-tools/)     | 1.1.0   | Read-only Atlassian access: Jira issues, JQL search, Confluence pages, CQL search, attachments    |
-| [bitwarden-code-review](plugins/bitwarden-code-review/)             | 1.8.0   | Autonomous code review agent following Bitwarden engineering standards with GitHub integration     |
-| [bitwarden-init](plugins/bitwarden-init/)                           | 1.1.0   | Initialize and enhance CLAUDE.md files with Bitwarden's standardized template format               |
-| [bitwarden-security-engineer](plugins/bitwarden-security-engineer/) | 0.2.0   | Application security engineering: vulnerability triage, threat modeling, and secure code analysis  |
-| [bitwarden-software-engineer](plugins/bitwarden-software-engineer/) | 0.3.0   | Full-stack engineering assistant for Bitwarden client, server, and database development patterns   |
-| [claude-config-validator](plugins/claude-config-validator/)         | 1.1.0   | Validates Claude Code configuration files for security, structure, and quality                     |
-| [claude-retrospective](plugins/claude-retrospective/)               | 1.1.0   | Analyze Claude Code sessions to identify successful patterns and improvement opportunities         |
+| Plugin                                                              | Version | Description                                                                                             |
+| ------------------------------------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------- |
+| [atlassian-reader](plugins/atlassian-reader/)                       | 1.2.1   | Read-only access to Jira issues, epics, sprints, boards, and Confluence pages from Atlassian Cloud      |
+| [bitwarden-atlassian-tools](plugins/bitwarden-atlassian-tools/)     | 1.1.1   | Read-only Atlassian access: Jira issues, JQL search, Confluence pages, CQL search, attachments          |
+| [bitwarden-code-review](plugins/bitwarden-code-review/)             | 1.8.1   | Autonomous code review agent following Bitwarden engineering standards with GitHub integration          |
+| [bitwarden-init](plugins/bitwarden-init/)                           | 1.1.0   | Initialize and enhance CLAUDE.md files with Bitwarden's standardized template format                    |
+| [bitwarden-product-analyst](plugins/bitwarden-product-analyst/)     | 0.1.4   | Product analyst agent for creating comprehensive Bitwarden requirements documents from multiple sources |
+| [bitwarden-security-engineer](plugins/bitwarden-security-engineer/) | 0.2.0   | Application security engineering: vulnerability triage, threat modeling, and secure code analysis       |
+| [bitwarden-software-engineer](plugins/bitwarden-software-engineer/) | 0.3.0   | Full-stack engineering assistant for Bitwarden client, server, and database development patterns        |
+| [claude-config-validator](plugins/claude-config-validator/)         | 1.1.1   | Validates Claude Code configuration files for security, structure, and quality                          |
+| [claude-retrospective](plugins/claude-retrospective/)               | 1.1.1   | Analyze Claude Code sessions to identify successful patterns and improvement opportunities              |
 
 ## Usage
 

--- a/plugins/atlassian-reader/.claude-plugin/plugin.json
+++ b/plugins/atlassian-reader/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atlassian-reader",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Read-only access to Jira issues, epics, sprints, boards, and Confluence pages from Atlassian Cloud.",
   "author": {
     "name": "Bitwarden",
@@ -16,6 +16,5 @@
     "agile",
     "read-only",
     "issue-tracking"
-  ],
-  "skills": "./skills/"
+  ]
 }

--- a/plugins/atlassian-reader/CHANGELOG.md
+++ b/plugins/atlassian-reader/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Atlassian Reader Plugin will be documented in this fi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] - 2026-03-12
+
+### Changed
+
+- Remove redundant `skills` field from `plugin.json`; skills are auto-discovered from the `skills/` directory
+
 ## [1.2.0] - 2026-02-23
 
 ### Added

--- a/plugins/bitwarden-code-review/.claude-plugin/plugin.json
+++ b/plugins/bitwarden-code-review/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bitwarden-code-review",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Comprehensive code review system with organization-wide standards.",
   "author": {
     "name": "Bitwarden",
@@ -22,12 +22,5 @@
   "commands": [
     "./commands/code-review/code-review.md",
     "./commands/code-review-local/code-review-local.md"
-  ],
-  "skills": [
-    "./skills/classifying-review-findings/SKILL.md",
-    "./skills/posting-bitwarden-review-comments/SKILL.md",
-    "./skills/avoiding-false-positives/SKILL.md",
-    "./skills/reviewing-incremental-changes/SKILL.md",
-    "./skills/posting-review-summary/SKILL.md"
   ]
 }

--- a/plugins/bitwarden-code-review/CHANGELOG.md
+++ b/plugins/bitwarden-code-review/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Bitwarden Code Review Plugin will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.1] - 2026-03-12
+
+### Fixed
+
+- Remove invalid `skills` field from `plugin.json` that listed individual `SKILL.md` file paths instead of directories; skills are auto-discovered from the `skills/` directory
+
 ## [1.8.0] - 2026-02-23
 
 ### Added

--- a/plugins/bitwarden-code-review/agents/bitwarden-code-reviewer/AGENT.md
+++ b/plugins/bitwarden-code-review/agents/bitwarden-code-reviewer/AGENT.md
@@ -1,6 +1,6 @@
 ---
 name: bitwarden-code-reviewer
-version: 1.8.0
+version: 1.8.1
 description: Conducts thorough code reviews following Bitwarden standards. Finds all issues first pass, avoids false positives, respects codebase conventions. Invoke when user mentions "code review", "review code", "review", "PR", or "pull request".
 model: opus
 skills: avoiding-false-positives, classifying-review-findings, posting-bitwarden-review-comments, posting-review-summary, reviewing-incremental-changes

--- a/plugins/bitwarden-product-analyst/.claude-plugin/plugin.json
+++ b/plugins/bitwarden-product-analyst/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bitwarden-product-analyst",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Product analyst agent for creating comprehensive Bitwarden requirements documents from multiple sources",
   "author": {
     "name": "Bitwarden",
@@ -14,6 +14,5 @@
     "specifications",
     "research"
   ],
-  "agents": "./agents/product-analyst.md",
-  "skills": "./skills/"
+  "agents": "./agents/product-analyst.md"
 }

--- a/plugins/bitwarden-product-analyst/CHANGELOG.md
+++ b/plugins/bitwarden-product-analyst/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Bitwarden Product Analyst plugin will be documented i
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.4] - 2026-03-12
+
+### Changed
+
+- Remove redundant `skills` field from `plugin.json`; skills are auto-discovered from the `skills/` directory
+
 ## [0.1.3] - 2026-03-12
 
 ### Changed

--- a/plugins/bitwarden-product-analyst/agents/product-analyst.md
+++ b/plugins/bitwarden-product-analyst/agents/product-analyst.md
@@ -1,6 +1,6 @@
 ---
 name: product-analyst
-version: 0.1.3
+version: 0.1.4
 description: Use when analyzing requirements, synthesizing specifications from multiple sources, or conducting product research. Trigger phrases: "analyze requirements", "create specification", "create spec", "write spec", "spec out", "spec document", "create a requirements doc", "research feature", "document requirements", "gather requirements", "write requirements", "product spec", "turn this into a spec"
 model: opus
 tools: Read, Write, Glob, Grep, WebSearch, WebFetch, Skill, AskUserQuestion

--- a/plugins/claude-config-validator/.claude-plugin/plugin.json
+++ b/plugins/claude-config-validator/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-config-validator",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Validates Claude Code configuration files for security, structure, and quality. Reviews CLAUDE.md, skills, agents, prompts, commands, and settings with comprehensive validation checklists.",
   "author": {
     "name": "Bitwarden",
@@ -16,6 +16,5 @@
     "claude-config",
     "code-review",
     "best-practices"
-  ],
-  "skills": "./skills/"
+  ]
 }

--- a/plugins/claude-config-validator/CHANGELOG.md
+++ b/plugins/claude-config-validator/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Claude Config Validator Plugin will be documented in 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2026-03-12
+
+### Changed
+
+- Remove redundant `skills` field from `plugin.json`; skills are auto-discovered from the `skills/` directory
+
 ## [1.1.0] - 2026-02-23
 
 ### Added

--- a/plugins/claude-retrospective/.claude-plugin/plugin.json
+++ b/plugins/claude-retrospective/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-retrospective",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Comprehensive analysis of Claude Code sessions to identify successful patterns, problematic areas, and opportunities for improvement.",
   "author": {
     "name": "Bitwarden",
@@ -14,6 +14,5 @@
     "session-review",
     "performance-insights",
     "improvement-opportunities"
-  ],
-  "skills": "./skills/"
+  ]
 }

--- a/plugins/claude-retrospective/CHANGELOG.md
+++ b/plugins/claude-retrospective/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Claude Retrospective Plugin will be documented in thi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2026-03-12
+
+### Changed
+
+- Remove redundant `skills` field from `plugin.json`; skills are auto-discovered from the `skills/` directory
+
 ## [1.1.0] - 2026-02-23
 
 ### Added


### PR DESCRIPTION
## 🎟️ Tracking

No JIRA task opened.

## 📔 Objective

The `skills` field in `plugin.json` is intended for skills stored in *non-standard locations*. Per the [plugin reference docs](https://code.claude.com/docs/en/plugins-reference), the `skills/` directory is auto-discovered by default — the field is only needed to supplement that with additional directories.

### Problems found

- **`bitwarden-code-review`**: Listed individual `SKILL.md` file paths in the `skills` array instead of directory paths — an invalid format per the spec. Skills were loading via auto-discovery anyway, masking the bug.
- **`atlassian-reader`, `bitwarden-product-analyst`, `claude-config-validator`, `claude-retrospective`**: Had `"skills": "./skills/"` which is redundant since `skills/` is auto-discovered.

### Fix

Remove the `skills` field from all affected `plugin.json` files. Auto-discovery handles everything correctly, consistent with how `bitwarden-security-engineer` and `bitwarden-software-engineer` already work.

## Version bumps

| Plugin | Old | New |
| --- | --- | --- |
| `atlassian-reader` | 1.2.0 | 1.2.1 |
| `bitwarden-code-review` | 1.8.0 | 1.8.1 |
| `bitwarden-product-analyst` | 0.1.3 | 0.1.4 |
| `claude-config-validator` | 1.1.0 | 1.1.1 |
| `claude-retrospective` | 1.1.0 | 1.1.1 |