### PR TITLE
Update README to use namespaced format for agents

### DIFF
--- a/plugins/bitwarden-security-engineer/README.md
+++ b/plugins/bitwarden-security-engineer/README.md
@@ -18,15 +18,15 @@ Claude Code skills for application security at Bitwarden. Generic AI coding assi
 Install the plugin and invoke the agent:
 
 ```
-Use the bitwarden-security-engineer agent to triage the open Checkmarx findings on this PR.
+Use the bitwarden-security-engineer:bitwarden-security-engineer agent to triage the open Checkmarx findings on this PR.
 ```
 
 ```
-Use the bitwarden-security-engineer agent to create a threat model for the new Send feature.
+Use the bitwarden-security-engineer:bitwarden-security-engineer agent to create a threat model for the new Send feature.
 ```
 
 ```
-Use the bitwarden-security-engineer agent to review this code for OWASP Top 10 vulnerabilities.
+Use the bitwarden-security-engineer:bitwarden-security-engineer agent to review this code for OWASP Top 10 vulnerabilities.
 ```
 
 ## References


### PR DESCRIPTION

## 📔 Objective

While using the agents, I noticed errors due to not having it fully namespaced. Claude eventually figured it out, but had big red text indicating the error. This should mitigate that, and use less tokens to figure out the fully qualified name.
