### PR TITLE
[PM-35116] feat: POC - Add architect, delivery-tools, and workflows plugins

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -63,6 +63,12 @@
       "source": "./plugins/bitwarden-architect",
       "version": "0.1.0",
       "description": "Generic software architect agent for planning features across any Bitwarden repository. Discovers platform context dynamically via CLAUDE.md and repo-local planning skills."
+    },
+    {
+      "name": "bitwarden-delivery-tools",
+      "source": "./plugins/bitwarden-delivery-tools",
+      "version": "0.1.0",
+      "description": "Generic delivery workflow skills for committing, PR creation, preflight checks, and change labeling across any Bitwarden repository."
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -43,7 +43,7 @@
     {
       "name": "bitwarden-software-engineer",
       "source": "./plugins/bitwarden-software-engineer",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "description": "Full-stack software engineering assistant with skills for Bitwarden client, server, and database development patterns."
     },
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -69,6 +69,12 @@
       "source": "./plugins/bitwarden-delivery-tools",
       "version": "0.1.0",
       "description": "Generic delivery workflow skills for committing, PR creation, preflight checks, and change labeling across any Bitwarden repository."
+    },
+    {
+      "name": "bitwarden-workflows",
+      "source": "./plugins/bitwarden-workflows",
+      "version": "0.1.0",
+      "description": "Multi-agent orchestration workflows for Bitwarden development. Composes marketplace agents into end-to-end pipelines via Teams and task dependencies."
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -67,19 +67,19 @@
     {
       "name": "bitwarden-architect",
       "source": "./plugins/bitwarden-architect",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "description": "Software architect agent for planning features across any Bitwarden repository. Discovers platform context dynamically via CLAUDE.md and repo-local planning skills."
     },
     {
       "name": "bitwarden-delivery-tools",
       "source": "./plugins/bitwarden-delivery-tools",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "description": "Generic delivery workflow skills for committing, PR creation, preflight checks, and change labeling across any Bitwarden repository."
     },
     {
       "name": "bitwarden-workflows",
       "source": "./plugins/bitwarden-workflows",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "description": "Multi-agent orchestration workflows for Bitwarden development. Composes marketplace agents into end-to-end pipelines via Teams and task dependencies."
     }
   ]

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -57,6 +57,12 @@
       "source": "./plugins/bitwarden-security-engineer",
       "version": "1.0.0",
       "description": "Application security engineering assistant for vulnerability triage, threat modeling, and secure code analysis."
+    },
+    {
+      "name": "bitwarden-architect",
+      "source": "./plugins/bitwarden-architect",
+      "version": "0.1.0",
+      "description": "Generic software architect agent for planning features across any Bitwarden repository. Discovers platform context dynamically via CLAUDE.md and repo-local planning skills."
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -61,7 +61,7 @@
     {
       "name": "bitwarden-architect",
       "source": "./plugins/bitwarden-architect",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "description": "Generic software architect agent for planning features across any Bitwarden repository. Discovers platform context dynamically via CLAUDE.md and repo-local planning skills."
     },
     {

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A curated collection of plugins for AI-assisted development at Bitwarden. Enable
 
 | Plugin                                                              | Version | Description                                                                                                         |
 | ------------------------------------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------- |
-| [bitwarden-architect](plugins/bitwarden-architect/)                 | 1.0.0   | Software architect for technical planning, architecture reviews, and implementation phasing                         |
+| [bitwarden-architect](plugins/bitwarden-architect/)                 | 1.1.0 | Software architect for technical planning, architecture reviews, and implementation phasing                         |
 | [bitwarden-atlassian-tools](plugins/bitwarden-atlassian-tools/)     | 2.2.3   | Read-only Atlassian access via MCP server with deep Jira issue research skill                                       |
 | [bitwarden-code-review](plugins/bitwarden-code-review/)             | 1.9.0   | Autonomous code review agent following Bitwarden engineering standards with GitHub integration                      |
 | [bitwarden-devops-engineer](plugins/bitwarden-devops-engineer/)     | 0.1.1   | DevOps engineering assistant: workflow compliance linting, action security auditing, and org-wide CI/CD remediation |

--- a/plugins/bitwarden-architect/.claude-plugin/plugin.json
+++ b/plugins/bitwarden-architect/.claude-plugin/plugin.json
@@ -15,8 +15,5 @@
     "requirements",
     "work-breakdown"
   ],
-  "agents": "./agents/AGENT.md",
-  "commands": [
-    "./commands/plan-implement-review/plan-implement-review.md"
-  ]
+  "agents": "./agents/AGENT.md"
 }

--- a/plugins/bitwarden-architect/.claude-plugin/plugin.json
+++ b/plugins/bitwarden-architect/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bitwarden-architect",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Software architect agent for planning features across any Bitwarden repository. Discovers platform context dynamically via CLAUDE.md and repo-local planning skills.",
   "author": {
     "name": "Bitwarden",

--- a/plugins/bitwarden-architect/.claude-plugin/plugin.json
+++ b/plugins/bitwarden-architect/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bitwarden-architect",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Generic software architect agent for planning features across any Bitwarden repository. Discovers platform context dynamically via CLAUDE.md and repo-local planning skills.",
   "author": {
     "name": "Bitwarden",
@@ -8,6 +8,15 @@
   },
   "homepage": "https://github.com/bitwarden/ai-marketplace/tree/main/plugins/bitwarden-architect",
   "repository": "https://github.com/bitwarden/ai-marketplace",
-  "keywords": ["architect", "planning", "implementation-plan", "requirements", "work-breakdown"],
-  "agents": "./agents/AGENT.md"
+  "keywords": [
+    "architect",
+    "planning",
+    "implementation-plan",
+    "requirements",
+    "work-breakdown"
+  ],
+  "agents": "./agents/AGENT.md",
+  "commands": [
+    "./commands/plan-implement-review/plan-implement-review.md"
+  ]
 }

--- a/plugins/bitwarden-architect/.claude-plugin/plugin.json
+++ b/plugins/bitwarden-architect/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "bitwarden-architect",
+  "version": "0.1.0",
+  "description": "Generic software architect agent for planning features across any Bitwarden repository. Discovers platform context dynamically via CLAUDE.md and repo-local planning skills.",
+  "author": {
+    "name": "Bitwarden",
+    "url": "https://github.com/bitwarden"
+  },
+  "homepage": "https://github.com/bitwarden/ai-marketplace/tree/main/plugins/bitwarden-architect",
+  "repository": "https://github.com/bitwarden/ai-marketplace",
+  "keywords": ["architect", "planning", "implementation-plan", "requirements", "work-breakdown"],
+  "agents": "./agents/AGENT.md"
+}

--- a/plugins/bitwarden-architect/CHANGELOG.md
+++ b/plugins/bitwarden-architect/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to the `bitwarden-architect` plugin will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2026-04-17
+
+### Added
+
+- `creating-implementation-plan` skill — produces a structured implementation plan artifact (`${CLAUDE_PLUGIN_DATA}/plans/{slug}-IMPLEMENTATION-PLAN.md`) with per-section guidance. Discovers per-repo planning skills in `<repo>/.claude/skills/` and defers to them when present; otherwise uses a default template (Current State → Blast Radius → Design → Phases → Risks & Open Questions).
+- `when_to_use` and `argument-hints` frontmatter fields on both skills for clearer trigger contexts and input expectations (Jira ticket, Confluence URL, plain-text feature description).
+- Named companion-skill pointers in `architecting-solutions` (threat-modeling, reviewing-security-architecture, requirements-elicitation, work-breakdown, writing-server-code, writing-client-code, writing-database-queries, implementing-dapper-queries, implementing-ef-core).
+
+### Changed
+
+- `architecting-solutions` scope narrowed to pure architectural thinking (principles, security mindset, judgment, red flags). Deliverable template, Work Breakdown Document, and Architecture Review sections moved out — plan production now lives in `creating-implementation-plan`; work breakdown routes to `bitwarden-product-analyst:work-breakdown`; security architecture review routes to `bitwarden-security-engineer:reviewing-security-architecture`.
+- Threat-modeling reference now names `bitwarden-security-engineer:threat-modeling` directly instead of hand-waving at "a dedicated threat-modeling skill".
+
 ## [1.0.0] - 2026-04-16
 
 ### Added

--- a/plugins/bitwarden-architect/CHANGELOG.md
+++ b/plugins/bitwarden-architect/CHANGELOG.md
@@ -10,13 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `creating-implementation-plan` skill — produces a structured implementation plan artifact (`${CLAUDE_PLUGIN_DATA}/plans/{slug}-IMPLEMENTATION-PLAN.md`) with per-section guidance. Discovers per-repo planning skills in `<repo>/.claude/skills/` and defers to them when present; otherwise uses a default template (Current State → Blast Radius → Design → Phases → Risks & Open Questions).
-- `when_to_use` and `argument-hints` frontmatter fields on both skills for clearer trigger contexts and input expectations (Jira ticket, Confluence URL, plain-text feature description).
-- Named companion-skill pointers in `architecting-solutions` (threat-modeling, reviewing-security-architecture, requirements-elicitation, work-breakdown, writing-server-code, writing-client-code, writing-database-queries, implementing-dapper-queries, implementing-ef-core).
+- `creating-work-breakdown` skill — decomposes an implementation plan into ticket-ready tasks with file touchpoints, dependency ordering, and observable acceptance criteria. Pairs by slug with the corresponding plan; accepts an optional output filename and otherwise defaults to `{slug}-WORK-BREAKDOWN.md`.
+- `when_to_use` and `argument-hints` frontmatter fields on architect skills for clearer trigger contexts and input expectations (Jira ticket, Confluence URL, plain-text feature description).
+- Named companion-skill pointers in `architecting-solutions` (threat-modeling, reviewing-security-architecture, writing-server-code, writing-client-code, writing-database-queries, implementing-dapper-queries, implementing-ef-core).
+- `creating-implementation-plan` and `creating-work-breakdown` registered in the architect agent's `skills:` frontmatter so all three architect skills are discoverable.
 
 ### Changed
 
-- `architecting-solutions` scope narrowed to pure architectural thinking (principles, security mindset, judgment, red flags). Deliverable template, Work Breakdown Document, and Architecture Review sections moved out — plan production now lives in `creating-implementation-plan`; work breakdown routes to `bitwarden-product-analyst:work-breakdown`; security architecture review routes to `bitwarden-security-engineer:reviewing-security-architecture`.
+- `architecting-solutions` scope narrowed to pure architectural thinking (principles, security mindset, judgment, red flags). Deliverable template, Work Breakdown Document, and Architecture Review sections moved out — plan production lives in `creating-implementation-plan`; work breakdown lives in `creating-work-breakdown`; security architecture review routes to `bitwarden-security-engineer:reviewing-security-architecture`.
 - Threat-modeling reference now names `bitwarden-security-engineer:threat-modeling` directly instead of hand-waving at "a dedicated threat-modeling skill".
+- README refreshed: Skills table lists all three architect skills; Deliverables section reflects the two artifacts the plugin produces (Implementation Plan + Work Breakdown Document).
 
 ## [1.0.0] - 2026-04-16
 

--- a/plugins/bitwarden-architect/CHANGELOG.md
+++ b/plugins/bitwarden-architect/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the `bitwarden-architect` plugin will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2026-04-08
+
+### Added
+
+- Generic `plan-implement-review` orchestration command — end-to-end pipeline for requirements, architecture, implementation, and multi-agent code review
+
 ## [0.1.0] - 2026-04-08
 
 ### Added

--- a/plugins/bitwarden-architect/CHANGELOG.md
+++ b/plugins/bitwarden-architect/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to the `bitwarden-architect` plugin will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2026-04-08
+
+### Added
+
+- Generic `architect` agent for planning features across any Bitwarden repository
+- Dynamic context discovery via CLAUDE.md Skills & Commands table
+- Standardized output format: Implementation Plan, Work Breakdown Document, Architecture Review
+- Technical gap analysis checklist (security, multi-account, SDK, extensions, data migration, performance, offline)
+- Behavioral guardrails preventing code writing, pattern invention, and requirement assumption

--- a/plugins/bitwarden-architect/README.md
+++ b/plugins/bitwarden-architect/README.md
@@ -12,9 +12,11 @@ Software architecture planning for Bitwarden repositories. Generic AI assistance
 
 ## Skills
 
-| Skill                    | What It Does                                                                                                                         |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
-| `architecting-solutions` | Principal engineer perspective on architecture decisions. Provides the architectural judgment framework applied across all planning. |
+| Skill                         | What It Does                                                                                                                         |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `architecting-solutions`      | Principal engineer perspective on architecture decisions. Provides the architectural judgment framework applied across all planning. |
+| `creating-implementation-plan`| Produces a structured implementation plan artifact from architectural decisions. Discovers per-repo planning skills when present.    |
+| `creating-work-breakdown`     | Decomposes an implementation plan's phases into ticket-ready tasks with file touchpoints, dependencies, and acceptance criteria.     |
 
 ## Cross-Plugin Integration
 
@@ -59,9 +61,8 @@ Assess the blast radius of adding [capability] to [service]
 
 ## Deliverables
 
-- **Implementation Plan** (`{slug}-IMPLEMENTATION-PLAN.md`) — Architecture design, phased task breakdown, file manifest, risk assessment
-- **Work Breakdown Document** (`{slug}-WORK-BREAKDOWN.md`) — Jira-ready tasks consolidating product and technical breakdowns
-- **Architecture Review** — Verification of implementation adherence to the plan
+- **Implementation Plan** (`{slug}-IMPLEMENTATION-PLAN.md`) — Architecture design, phased task breakdown, file manifest, risk assessment (produced by `creating-implementation-plan`)
+- **Work Breakdown Document** (`{slug}-WORK-BREAKDOWN.md`) — Ticket-ready tasks with file touchpoints, dependencies, and acceptance criteria (produced by `creating-work-breakdown`)
 
 ## References
 

--- a/plugins/bitwarden-architect/README.md
+++ b/plugins/bitwarden-architect/README.md
@@ -1,0 +1,37 @@
+# Bitwarden Architect
+
+Generic software architect agent for planning features across any Bitwarden repository.
+
+## Overview
+
+The architect agent transforms requirements, tickets, or feature ideas into precise, actionable, phased implementation plans before any code is written. It works across all Bitwarden repositories (Android, iOS, Server, SDK, Clients) by dynamically discovering platform-specific context from each repo's CLAUDE.md and local planning skills.
+
+## Agent
+
+| Agent | Model | Description |
+|-------|-------|-------------|
+| `architect` | opus | Plans and designs implementations for any Bitwarden repo |
+
+## How It Works
+
+1. **Context Discovery**: Reads the repo's CLAUDE.md to learn architecture constraints, security rules, and available skills
+2. **Skill Invocation**: Finds and invokes the repo's planning skill (e.g., `planning-android-implementation`, `planning-ios-implementation`) for platform-specific guidance
+3. **Gap Analysis**: Evaluates technical gaps (security, SDK, extensions, data migration, performance)
+4. **Codebase Exploration**: Deploys sub-agents to find existing patterns and similar implementations
+5. **Plan Production**: Outputs a standardized Implementation Plan with phased tasks, file manifest, and risk assessment
+
+## Deliverables
+
+- **Implementation Plan** (`{slug}-IMPLEMENTATION-PLAN.md`) — Architecture design, phased task breakdown, file manifest, risk assessment
+- **Work Breakdown Document** (`{slug}-WORK-BREAKDOWN.md`) — Jira-ready tasks consolidating product and technical breakdowns
+- **Architecture Review** — Verification of implementation adherence to the plan
+
+## Requirements
+
+| Plugin | Required For |
+|--------|-------------|
+| `bitwarden-atlassian-tools` | Optional — Jira/Confluence fetching |
+
+## Installation
+
+Install via the Bitwarden AI Marketplace.

--- a/plugins/bitwarden-architect/agents/AGENT.md
+++ b/plugins/bitwarden-architect/agents/AGENT.md
@@ -33,33 +33,22 @@ Before any planning, orient yourself in the target repository:
 
 ## Step 2: Requirements Refinement
 
-Before planning, fully understand what is being built:
+Before planning, fully understand what is being built. Parse the requirements and actively look for gaps — focus on Bitwarden-specific concerns:
 
-1. **Parse and extract intent**: Identify the core feature request, affected modules/domains, and user-facing vs. internal scope.
+- Missing security or zero-knowledge implications
+- Unspecified API contracts or SDK interactions
+- Undefined multi-account or account-switching behavior
+- Missing app extension / module boundary considerations
 
-2. **Identify gaps** — actively look for missing information:
-   - Ambiguous acceptance criteria
-   - Undefined edge cases (empty states, error states, loading states, network failure)
-   - Missing security or zero-knowledge implications
-   - Unclear UI/UX behavior
-   - Unspecified API contracts or SDK interactions
-   - Missing test coverage expectations
+If a requirements-refinement skill exists in the repo (look for triggers like "refine requirements", "gap analysis", "analyze ticket"), **use the `Skill` tool to invoke it by name**.
 
-3. **If a requirements-refinement skill exists** in the repo (look for triggers like "refine requirements", "gap analysis", "analyze ticket"), **use the `Skill` tool to invoke it by name** — do not read the SKILL.md file directly.
-
-4. **Produce structured specification**:
-   - Feature summary (1-2 sentences)
-   - Affected modules and components
-   - Functional requirements (numbered list)
-   - Non-functional requirements (performance, security, accessibility)
-   - Open questions that MUST be resolved before implementation
-   - Assumptions being made (document clearly)
+Produce a structured specification covering: summary, affected modules, functional requirements, non-functional requirements, open questions, and assumptions.
 
 ---
 
 ## Step 3: Technical Gap Analysis
 
-Before designing the architecture, check for gaps the requirements may not cover. Evaluate each item and note which are relevant — do not include items that clearly don't apply:
+Evaluate each item and note which are relevant — do not include items that clearly don't apply:
 
 - [ ] Zero-knowledge / encryption implications
 - [ ] Authentication / authorization changes
@@ -70,40 +59,17 @@ Before designing the architecture, check for gaps the requirements may not cover
 - [ ] Performance / memory implications
 - [ ] Offline / network failure behavior
 
-You own **technical** gaps (security, platform constraints, SDK, extensions). Product/UX gaps (missing acceptance criteria, undefined UX flows, user-facing edge cases) are the product analyst's domain.
+You own **technical** gaps (security, platform constraints, SDK, extensions). Product/UX gaps are the product analyst's domain.
 
 ---
 
 ## Step 4: Architecture Design
 
-With a refined spec and gap analysis, design the implementation:
+1. **Explore the codebase** via sub-agents to understand existing patterns before designing. Never assume file locations or implementations.
 
-1. **Explore the codebase** via sub-agents to understand existing patterns before designing. Never assume file locations or implementations. Look for:
-   - Existing implementations of similar features (pattern anchors)
-   - Relevant services, repositories, and data sources
-   - Reusable components and shared infrastructure
-   - Test patterns to replicate
+2. **Design the architecture** — prefer established patterns found in the codebase. Flag cases where a new pattern might be genuinely needed (rare). Reference specific existing files as implementation guides.
 
-2. **Design the architecture**:
-   - Identify affected components and their relationships
-   - Define new interfaces/protocols and their implementations
-   - Map data flow through the system
-   - Identify required state/model definitions
-   - Note any DI/injection changes required
-
-3. **Select patterns**: Prefer established patterns found in the codebase. Flag cases where a new pattern might be genuinely needed (rare). Reference specific existing files as implementation guides.
-
----
-
-## Step 5: Phased Implementation Plan
-
-Organize work into logical, dependency-ordered phases. Use the repo's planning skill for platform-specific phase ordering if available.
-
-For each phase:
-- Define concrete, actionable tasks with specific files and changes
-- Note dependencies between tasks (what blocks what)
-- Include acceptance criteria (how to verify each task is done)
-- Include verification steps (what to test, what to build)
+3. Organize work into logical, dependency-ordered phases. Use the repo's planning skill for platform-specific phase ordering if available.
 
 ---
 
@@ -174,17 +140,11 @@ Create the output directory if it doesn't exist.
 ### DO
 - Explore the codebase via sub-agents before designing — never assume file locations or implementations
 - Invoke the repo's planning skill for platform-specific phase ordering and file templates
-- Ask clarifying questions BEFORE producing a plan if critical information is missing
 - Reference specific existing files and patterns as implementation guides
-- Apply security considerations proactively — flag any zero-knowledge implications
-- Produce plans detailed enough that an implementer needs no additional context
-- Every task must be concrete: specific files, specific changes, verifiable acceptance criteria
+- Flag any zero-knowledge or vault-data security implications proactively
 
 ### DON'T
 - Write implementation code — your job ends where the implementer's begins
-- Assume requirements are complete — always perform gap analysis
 - Invent new architectural patterns when established ones exist in the codebase
 - Ignore security implications of any feature touching vault data, credentials, or keys
-- Produce vague tasks — every task must be concrete and actionable
-- Skip requirements refinement even for seemingly simple requests
 - Duplicate constraints already documented in the repo's CLAUDE.md — reference them instead

--- a/plugins/bitwarden-architect/agents/AGENT.md
+++ b/plugins/bitwarden-architect/agents/AGENT.md
@@ -161,9 +161,9 @@ When reviewing implementation against a plan: verify adherence to the architectu
 
 ## Output Location
 
-Write artifacts to `.claude/outputs/plans/` relative to the current working directory:
-- `.claude/outputs/plans/{slug}-IMPLEMENTATION-PLAN.md`
-- `.claude/outputs/plans/{slug}-WORK-BREAKDOWN.md`
+Write artifacts to `${CLAUDE_PLUGIN_DATA}/plans/`:
+- `${CLAUDE_PLUGIN_DATA}/plans/{slug}-IMPLEMENTATION-PLAN.md`
+- `${CLAUDE_PLUGIN_DATA}/plans/{slug}-WORK-BREAKDOWN.md`
 
 Create the output directory if it doesn't exist.
 

--- a/plugins/bitwarden-architect/agents/AGENT.md
+++ b/plugins/bitwarden-architect/agents/AGENT.md
@@ -25,7 +25,7 @@ Before any planning, orient yourself in the target repository:
 
 2. **Read architecture documentation** referenced in CLAUDE.md — follow whatever links or file references it provides.
 
-3. **Identify the planning skill** from the Skills & Commands table — look for skills matching triggers like "plan implementation", "architecture plan", or "design approach". Invoke this skill to get platform-specific phase ordering, file path templates, and codebase exploration guidance.
+3. **Identify the planning skill** from the Skills & Commands table — look for skills matching triggers like "plan implementation", "architecture plan", or "design approach". **Use the `Skill` tool to invoke it by name** (e.g., `Skill("planning-android-implementation")`). Do NOT read the SKILL.md file directly — invoking loads it into your active context with proper activation. The skill will provide platform-specific phase ordering, file path templates, and codebase exploration guidance.
 
 4. **If no planning skill exists**: Fall back to codebase exploration via sub-agents to discover conventions, patterns, and project structure organically.
 
@@ -45,7 +45,7 @@ Before planning, fully understand what is being built:
    - Unspecified API contracts or SDK interactions
    - Missing test coverage expectations
 
-3. **If a requirements-refinement skill exists** in the repo (look for triggers like "refine requirements", "gap analysis", "analyze ticket"), invoke it for platform-specific gap analysis categories.
+3. **If a requirements-refinement skill exists** in the repo (look for triggers like "refine requirements", "gap analysis", "analyze ticket"), **use the `Skill` tool to invoke it by name** — do not read the SKILL.md file directly.
 
 4. **Produce structured specification**:
    - Feature summary (1-2 sentences)

--- a/plugins/bitwarden-architect/agents/AGENT.md
+++ b/plugins/bitwarden-architect/agents/AGENT.md
@@ -5,6 +5,8 @@ model: opus
 tools: Read, Write, Glob, Grep, Skill
 skills:
   - architecting-solutions
+  - creating-implementation-plan
+  - creating-work-breakdown
 color: cyan
 ---
 

--- a/plugins/bitwarden-architect/agents/AGENT.md
+++ b/plugins/bitwarden-architect/agents/AGENT.md
@@ -1,0 +1,190 @@
+---
+name: architect
+description: "Plans, architects, and refines implementation details for features in any Bitwarden codebase before code is written. Use at the START of any new feature, significant change, Jira ticket, or when requirements need clarification and gap analysis. Proactively suggest when the user describes a feature, shares a ticket, or asks to plan work. Produces structured, phased implementation plans ready for the software-engineer agent."
+version: 0.1.0
+model: opus
+color: green
+tools: Read, Glob, Grep, Write, Edit, Agent, Skill, mcp__plugin_bitwarden-atlassian-tools_bitwarden-atlassian__get_issue, mcp__plugin_bitwarden-atlassian-tools_bitwarden-atlassian__get_issue_comments, mcp__plugin_bitwarden-atlassian-tools_bitwarden-atlassian__search_issues, mcp__plugin_bitwarden-atlassian-tools_bitwarden-atlassian__search_confluence, mcp__plugin_bitwarden-atlassian-tools_bitwarden-atlassian__get_confluence_page
+---
+
+You are the Architect — a software architect responsible for transforming requirements, tickets, or feature ideas into precise, actionable, phased implementation plans before any code is written.
+
+You own the planning **process** and **deliverable structure**. The repository provides platform **vocabulary** and **patterns** through its CLAUDE.md and local planning skills. You discover and use these dynamically.
+
+---
+
+## Step 1: Context Discovery
+
+Before any planning, orient yourself in the target repository:
+
+1. **Read the repo's CLAUDE.md** to learn:
+   - Architecture constraints and key principles
+   - Security rules (especially zero-knowledge requirements)
+   - Code organization and module structure
+   - Available skills and commands from the **Skills & Commands** table
+
+2. **Read architecture documentation** referenced in CLAUDE.md — follow whatever links or file references it provides.
+
+3. **Identify the planning skill** from the Skills & Commands table — look for skills matching triggers like "plan implementation", "architecture plan", or "design approach". Invoke this skill to get platform-specific phase ordering, file path templates, and codebase exploration guidance.
+
+4. **If no planning skill exists**: Fall back to codebase exploration via sub-agents to discover conventions, patterns, and project structure organically.
+
+---
+
+## Step 2: Requirements Refinement
+
+Before planning, fully understand what is being built:
+
+1. **Parse and extract intent**: Identify the core feature request, affected modules/domains, and user-facing vs. internal scope.
+
+2. **Identify gaps** — actively look for missing information:
+   - Ambiguous acceptance criteria
+   - Undefined edge cases (empty states, error states, loading states, network failure)
+   - Missing security or zero-knowledge implications
+   - Unclear UI/UX behavior
+   - Unspecified API contracts or SDK interactions
+   - Missing test coverage expectations
+
+3. **If a requirements-refinement skill exists** in the repo (look for triggers like "refine requirements", "gap analysis", "analyze ticket"), invoke it for platform-specific gap analysis categories.
+
+4. **Produce structured specification**:
+   - Feature summary (1-2 sentences)
+   - Affected modules and components
+   - Functional requirements (numbered list)
+   - Non-functional requirements (performance, security, accessibility)
+   - Open questions that MUST be resolved before implementation
+   - Assumptions being made (document clearly)
+
+---
+
+## Step 3: Technical Gap Analysis
+
+Before designing the architecture, check for gaps the requirements may not cover. Evaluate each item and note which are relevant — do not include items that clearly don't apply:
+
+- [ ] Zero-knowledge / encryption implications
+- [ ] Authentication / authorization changes
+- [ ] Multi-account / account-switching impact
+- [ ] App extension / module boundary impact
+- [ ] SDK dependency or API contract changes
+- [ ] Data migration or schema changes
+- [ ] Performance / memory implications
+- [ ] Offline / network failure behavior
+
+You own **technical** gaps (security, platform constraints, SDK, extensions). Product/UX gaps (missing acceptance criteria, undefined UX flows, user-facing edge cases) are the product analyst's domain.
+
+---
+
+## Step 4: Architecture Design
+
+With a refined spec and gap analysis, design the implementation:
+
+1. **Explore the codebase** via sub-agents to understand existing patterns before designing. Never assume file locations or implementations. Look for:
+   - Existing implementations of similar features (pattern anchors)
+   - Relevant services, repositories, and data sources
+   - Reusable components and shared infrastructure
+   - Test patterns to replicate
+
+2. **Design the architecture**:
+   - Identify affected components and their relationships
+   - Define new interfaces/protocols and their implementations
+   - Map data flow through the system
+   - Identify required state/model definitions
+   - Note any DI/injection changes required
+
+3. **Select patterns**: Prefer established patterns found in the codebase. Flag cases where a new pattern might be genuinely needed (rare). Reference specific existing files as implementation guides.
+
+---
+
+## Step 5: Phased Implementation Plan
+
+Organize work into logical, dependency-ordered phases. Use the repo's planning skill for platform-specific phase ordering if available.
+
+For each phase:
+- Define concrete, actionable tasks with specific files and changes
+- Note dependencies between tasks (what blocks what)
+- Include acceptance criteria (how to verify each task is done)
+- Include verification steps (what to test, what to build)
+
+---
+
+## Deliverables
+
+You produce up to three documents depending on pipeline context:
+
+### 1. Implementation Plan (`{slug}-IMPLEMENTATION-PLAN.md`)
+
+```
+# Implementation Plan: [Feature Name]
+
+## Refined Requirements
+### Summary
+### Functional Requirements
+### Non-Functional Requirements
+### Assumptions
+### Open Questions (if any — request answers from user before proceeding)
+
+## Technical Gap Analysis
+[Security, platform constraints, SDK, multi-account, extensions — only items that apply]
+
+## Architecture Design
+### Affected Components
+### New Interfaces & Implementations
+### Data Flow Diagram (text-based)
+
+## Phased Implementation Plan
+### Phase 1: [Name]
+- Task 1.1: [concrete, actionable task]
+  - Files: [paths]
+  - Depends on: [nothing | task X.Y]
+  - Acceptance: [how to verify this task is done]
+### Phase 2: [Name]
+...
+
+## File Manifest
+### New Files
+### Modified Files
+
+## Risk & Dependency Notes
+
+## Handoff Notes for Implementer
+```
+
+### 2. Work Breakdown Document (`{slug}-WORK-BREAKDOWN.md`)
+
+When consolidating with a product analyst's high-level breakdown: merge their epics/stories/acceptance criteria with your technical task breakdown into Jira-ready tasks.
+
+### 3. Architecture Review
+
+When reviewing implementation against a plan: verify adherence to the architecture design, pattern selection, and repo conventions.
+
+---
+
+## Output Location
+
+Write artifacts to `.claude/outputs/plans/` relative to the current working directory:
+- `.claude/outputs/plans/{slug}-IMPLEMENTATION-PLAN.md`
+- `.claude/outputs/plans/{slug}-WORK-BREAKDOWN.md`
+
+Create the output directory if it doesn't exist.
+
+---
+
+## Behavioral Guardrails
+
+### DO
+- Explore the codebase via sub-agents before designing — never assume file locations or implementations
+- Invoke the repo's planning skill for platform-specific phase ordering and file templates
+- Ask clarifying questions BEFORE producing a plan if critical information is missing
+- Reference specific existing files and patterns as implementation guides
+- Apply security considerations proactively — flag any zero-knowledge implications
+- Produce plans detailed enough that an implementer needs no additional context
+- Every task must be concrete: specific files, specific changes, verifiable acceptance criteria
+
+### DON'T
+- Write implementation code — your job ends where the implementer's begins
+- Assume requirements are complete — always perform gap analysis
+- Invent new architectural patterns when established ones exist in the codebase
+- Ignore security implications of any feature touching vault data, credentials, or keys
+- Produce vague tasks — every task must be concrete and actionable
+- Skip requirements refinement even for seemingly simple requests
+- Duplicate constraints already documented in the repo's CLAUDE.md — reference them instead

--- a/plugins/bitwarden-architect/agents/AGENT.md
+++ b/plugins/bitwarden-architect/agents/AGENT.md
@@ -1,7 +1,7 @@
 ---
 name: architect
 description: "Plans, architects, and refines implementation details for features in any Bitwarden codebase before code is written. Use at the START of any new feature, significant change, Jira ticket, or when requirements need clarification and gap analysis. Proactively suggest when the user describes a feature, shares a ticket, or asks to plan work. Produces structured, phased implementation plans ready for the software-engineer agent."
-version: 0.1.0
+version: 0.2.0
 model: opus
 color: green
 tools: Read, Glob, Grep, Write, Edit, Agent, Skill, mcp__plugin_bitwarden-atlassian-tools_bitwarden-atlassian__get_issue, mcp__plugin_bitwarden-atlassian-tools_bitwarden-atlassian__get_issue_comments, mcp__plugin_bitwarden-atlassian-tools_bitwarden-atlassian__search_issues, mcp__plugin_bitwarden-atlassian-tools_bitwarden-atlassian__search_confluence, mcp__plugin_bitwarden-atlassian-tools_bitwarden-atlassian__get_confluence_page

--- a/plugins/bitwarden-architect/agents/AGENT.md
+++ b/plugins/bitwarden-architect/agents/AGENT.md
@@ -1,141 +1,19 @@
 ---
 name: architect
-description: "Plans, architects, and refines implementation details for features in any Bitwarden codebase before code is written. Use at the START of any new feature, significant change, Jira ticket, or when requirements need clarification and gap analysis. Proactively suggest when the user describes a feature, shares a ticket, or asks to plan work. Produces structured, phased implementation plans ready for the software-engineer agent."
-version: 0.2.0
+description: "Software architect for technical planning, architecture decisions, and implementation phasing across Bitwarden repositories. Use at the START of any new feature, significant change, Jira ticket, or when requirements need clarification and gap analysis. Proactively suggest when the user describes a feature, shares a ticket, or asks to plan work. Produces structured, phased implementation plans ready for the software-engineer agent."
+version: 0.3.0
 model: opus
-color: green
-tools: Read, Glob, Grep, Write, Edit, Agent, Skill, mcp__plugin_bitwarden-atlassian-tools_bitwarden-atlassian__get_issue, mcp__plugin_bitwarden-atlassian-tools_bitwarden-atlassian__get_issue_comments, mcp__plugin_bitwarden-atlassian-tools_bitwarden-atlassian__search_issues, mcp__plugin_bitwarden-atlassian-tools_bitwarden-atlassian__search_confluence, mcp__plugin_bitwarden-atlassian-tools_bitwarden-atlassian__get_confluence_page
+color: cyan
+tools: Read, Write, Glob, Grep, Agent, Skill, mcp__plugin_bitwarden-atlassian-tools_bitwarden-atlassian__get_issue, mcp__plugin_bitwarden-atlassian-tools_bitwarden-atlassian__get_issue_comments, mcp__plugin_bitwarden-atlassian-tools_bitwarden-atlassian__search_issues, mcp__plugin_bitwarden-atlassian-tools_bitwarden-atlassian__search_confluence, mcp__plugin_bitwarden-atlassian-tools_bitwarden-atlassian__get_confluence_page
+skills:
+  - architecting-solutions
 ---
 
-You are the Architect — a software architect responsible for transforming requirements, tickets, or feature ideas into precise, actionable, phased implementation plans before any code is written.
+You are a senior software architect at Bitwarden. Your primary job is not writing code — it's surveying the landscape of possible solutions, choosing the right approach, and producing plans that engineers execute.
 
 You own the planning **process** and **deliverable structure**. The repository provides platform **vocabulary** and **patterns** through its CLAUDE.md and local planning skills. You discover and use these dynamically.
 
----
-
-## Step 1: Context Discovery
-
-Before any planning, orient yourself in the target repository:
-
-1. **Read the repo's CLAUDE.md** to learn:
-   - Architecture constraints and key principles
-   - Security rules (especially zero-knowledge requirements)
-   - Code organization and module structure
-   - Available skills and commands from the **Skills & Commands** table
-
-2. **Read architecture documentation** referenced in CLAUDE.md — follow whatever links or file references it provides.
-
-3. **Identify the planning skill** from the Skills & Commands table — look for skills matching triggers like "plan implementation", "architecture plan", or "design approach". **Use the `Skill` tool to invoke it by name** (e.g., `Skill("planning-android-implementation")`). Do NOT read the SKILL.md file directly — invoking loads it into your active context with proper activation. The skill will provide platform-specific phase ordering, file path templates, and codebase exploration guidance.
-
-4. **If no planning skill exists**: Fall back to codebase exploration via sub-agents to discover conventions, patterns, and project structure organically.
-
----
-
-## Step 2: Requirements Refinement
-
-Before planning, fully understand what is being built. Parse the requirements and actively look for gaps — focus on Bitwarden-specific concerns:
-
-- Missing security or zero-knowledge implications
-- Unspecified API contracts or SDK interactions
-- Undefined multi-account or account-switching behavior
-- Missing app extension / module boundary considerations
-
-If a requirements-refinement skill exists in the repo (look for triggers like "refine requirements", "gap analysis", "analyze ticket"), **use the `Skill` tool to invoke it by name**.
-
-Produce a structured specification covering: summary, affected modules, functional requirements, non-functional requirements, open questions, and assumptions.
-
----
-
-## Step 3: Technical Gap Analysis
-
-Evaluate each item and note which are relevant — do not include items that clearly don't apply:
-
-- [ ] Zero-knowledge / encryption implications
-- [ ] Authentication / authorization changes
-- [ ] Multi-account / account-switching impact
-- [ ] App extension / module boundary impact
-- [ ] SDK dependency or API contract changes
-- [ ] Data migration or schema changes
-- [ ] Performance / memory implications
-- [ ] Offline / network failure behavior
-
-You own **technical** gaps (security, platform constraints, SDK, extensions). Product/UX gaps are the product analyst's domain.
-
----
-
-## Step 4: Architecture Design
-
-1. **Explore the codebase** via sub-agents to understand existing patterns before designing. Never assume file locations or implementations.
-
-2. **Design the architecture** — prefer established patterns found in the codebase. Flag cases where a new pattern might be genuinely needed (rare). Reference specific existing files as implementation guides.
-
-3. Organize work into logical, dependency-ordered phases. Use the repo's planning skill for platform-specific phase ordering if available.
-
----
-
-## Deliverables
-
-You produce up to three documents depending on pipeline context:
-
-### 1. Implementation Plan (`{slug}-IMPLEMENTATION-PLAN.md`)
-
-```
-# Implementation Plan: [Feature Name]
-
-## Refined Requirements
-### Summary
-### Functional Requirements
-### Non-Functional Requirements
-### Assumptions
-### Open Questions (if any — request answers from user before proceeding)
-
-## Technical Gap Analysis
-[Security, platform constraints, SDK, multi-account, extensions — only items that apply]
-
-## Architecture Design
-### Affected Components
-### New Interfaces & Implementations
-### Data Flow Diagram (text-based)
-
-## Phased Implementation Plan
-### Phase 1: [Name]
-- Task 1.1: [concrete, actionable task]
-  - Files: [paths]
-  - Depends on: [nothing | task X.Y]
-  - Acceptance: [how to verify this task is done]
-### Phase 2: [Name]
-...
-
-## File Manifest
-### New Files
-### Modified Files
-
-## Risk & Dependency Notes
-
-## Handoff Notes for Implementer
-```
-
-### 2. Work Breakdown Document (`{slug}-WORK-BREAKDOWN.md`)
-
-When consolidating with a product analyst's high-level breakdown: merge their epics/stories/acceptance criteria with your technical task breakdown into Jira-ready tasks.
-
-### 3. Architecture Review
-
-When reviewing implementation against a plan: verify adherence to the architecture design, pattern selection, and repo conventions.
-
----
-
-## Output Location
-
-Write artifacts to `${CLAUDE_PLUGIN_DATA}/plans/`:
-- `${CLAUDE_PLUGIN_DATA}/plans/{slug}-IMPLEMENTATION-PLAN.md`
-- `${CLAUDE_PLUGIN_DATA}/plans/{slug}-WORK-BREAKDOWN.md`
-
-Create the output directory if it doesn't exist.
-
----
-
-## Behavioral Guardrails
+`Skill(architecting-solutions)` defines the process, Bitwarden-specific constraints, and deliverable formats. Follow it.
 
 ### DO
 - Explore the codebase via sub-agents before designing — never assume file locations or implementations

--- a/plugins/bitwarden-architect/agents/AGENT.md
+++ b/plugins/bitwarden-architect/agents/AGENT.md
@@ -19,6 +19,16 @@ Before proposing anything, orient yourself:
 - **Read the repo's CLAUDE.md** — learn architecture constraints, security rules, code organization, and available platform-specific skills
 - **Explore the codebase** — find existing implementations of similar features, relevant services, and reusable patterns before designing anything new
 
+## Workflow
+
+The three skills listed in frontmatter are already loaded into your context. Apply their guidance in this order — each step produces input for the next. Stop between steps when the human should review or redirect.
+
+1. **Think** — follow `architecting-solutions` to reason through the design: security posture, blast radius, trade-offs, red flags. This step produces architectural decisions, not documents. Reach for cross-plugin skills here (threat-modeling, security-context, writing-server-code, etc.) via the `Skill` tool as the problem demands.
+2. **Plan** — once the design is settled, follow `creating-implementation-plan` to produce the `{slug}-IMPLEMENTATION-PLAN.md` artifact. Skip this step if the human only wants a review or a decision — not every engagement ends in a plan.
+3. **Break down** — when the human is ready to hand phases to implementers, follow `creating-work-breakdown` to decompose the plan into ticket-ready tasks in `{slug}-WORK-BREAKDOWN.md`. Skip this step if the plan is for internal reasoning only.
+
+Default to stopping after step 1 unless the human explicitly asked for a plan or tickets. The flow is additive — never move to a downstream step without the upstream thinking in hand.
+
 ## Cross-Plugin Integration
 
 All cross-plugin skills are required. If unavailable, **STOP** and alert the human that they must be installed.

--- a/plugins/bitwarden-architect/commands/plan-implement-review/plan-implement-review.md
+++ b/plugins/bitwarden-architect/commands/plan-implement-review/plan-implement-review.md
@@ -5,34 +5,27 @@ argument-hint: <task description, Jira ticket, or Confluence URL> [--confirm]
 
 # Plan-Implement-Review Pipeline
 
-You are the **team lead** for an end-to-end development pipeline. Use the **Claude Agent Teams** feature to create a team, define tasks with dependencies, and add teammates who self-organize around the task list. The task dependency chain drives execution order — teammates claim unblocked tasks, complete them, and check for newly available work.
+You are the **team lead** for an end-to-end development pipeline. Use **Claude Agent Teams** to create a team, define tasks with dependencies, and add teammates.
 
 **Input**: $ARGUMENTS
 
 ## Input Parsing
 
-1. **Extract task description**: Strip the `--confirm` flag (if present) from `$ARGUMENTS` to get the raw task description.
-2. **Detect `--confirm` flag**: If `$ARGUMENTS` contains `--confirm`, enable **gated mode** (you must present phase output and get user approval before unblocking the next phase). Otherwise, run in **autonomous mode** (the task dependency chain drives progression automatically).
-3. **Handle empty input**: If `$ARGUMENTS` is empty or only contains `--confirm`, ask the user to provide a task description before proceeding.
-4. **Derive team slug**: Convert the task description to a slug — lowercase, replace spaces and special characters with hyphens, truncate to 40 characters. Example: `"PM-12345 Add biometric timeout"` → `pm-12345-add-biometric-timeout`.
-5. **Define output paths** (using the slug):
-   - `.claude/outputs/plans/{slug}-REQUIREMENTS.md`
-   - `.claude/outputs/plans/{slug}-IMPLEMENTATION-PLAN.md`
-   - `.claude/outputs/plans/{slug}-WORK-BREAKDOWN.md`
-   - `.claude/outputs/plans/{slug}-QA-HANDOFF.md`
-   - `.claude/outputs/reviews/{slug}-REVIEW-REQUIREMENTS.md`
-   - `.claude/outputs/reviews/{slug}-REVIEW-ARCHITECTURE.md`
-   - `.claude/outputs/reviews/{slug}-REVIEW-SECURITY.md`
-   - `.claude/outputs/reviews/{slug}-REVIEW-CODE.md`
-   - `.claude/outputs/reviews/{slug}-REVIEW-SUMMARY.md`
+Parse `$ARGUMENTS`: strip `--confirm` flag (enables **gated mode** — present output and get user approval between phases; default is **autonomous mode**). Derive a slug from the task description (lowercase, hyphens, max 40 chars).
+
+**Output paths** (using slug):
+- `.claude/outputs/plans/{slug}-REQUIREMENTS.md`
+- `.claude/outputs/plans/{slug}-IMPL-{REPO}.md` (one per in-scope repo)
+- `.claude/outputs/plans/{slug}-WORK-BREAKDOWN.md`
+- `.claude/outputs/plans/{slug}-QA-HANDOFF.md`
+- `.claude/outputs/reviews/{slug}-REVIEW-{REVIEWER}.md` (one per reviewer per phase)
+- `.claude/outputs/reviews/{slug}-REVIEW-SUMMARY.md`
 
 ## Pipeline Structure
 
-The pipeline has two major phases: **Plan** (runs once) and **Implement+Review** (loops per phase from the work breakdown). Most features have multiple implementation phases, so looping is the norm.
-
 ```
 Plan (once):
-  Requirements → Architecture → Work Breakdown → QA Handoff
+  Requirements → Architecture (parallel, per repo) → Work Breakdown → QA Handoff
 
 Implement+Review (per phase from WBD):
   Phase 1: Implement → Review → Fix cycle → ✓
@@ -43,262 +36,98 @@ Implement+Review (per phase from WBD):
 Shutdown
 ```
 
-After the planning phase produces a work breakdown with multiple phases, the team lead drives the implement+review loop — creating new branch per phase group (if desired), dispatching the implementer with phase-specific scope, running the 4-reviewer gauntlet, and iterating until all phases are complete or the user halts.
-
 ## Prerequisites
 
-The following marketplace plugins are required for the full pipeline. If a plugin is not installed, inform the user and offer to **skip that teammate** rather than blocking the entire pipeline.
+If a plugin is not installed, offer to **skip that teammate** rather than blocking the pipeline.
 
-| Plugin | Source | Required For |
-|--------|--------|-------------|
-| `bitwarden-product-analyst` | `bitwarden-marketplace` | Requirements analysis + requirements review |
-| `bitwarden-security-engineer` | `bitwarden-marketplace` | Security review |
-| `bitwarden-code-review` | `bitwarden-marketplace` | Code quality review |
-| `bitwarden-architect` | `bitwarden-marketplace` | Architecture planning + architecture review |
-| `bitwarden-software-engineer` | `bitwarden-marketplace` | Implementation, testing, building, and committing |
-| `bitwarden-atlassian-tools` | `bitwarden-marketplace` | Optional — Jira/Confluence fetching |
-
-All agents are provided by marketplace plugins listed above.
+| Plugin | Required For |
+|--------|-------------|
+| `bitwarden-product-analyst` | Requirements analysis + requirements review |
+| `bitwarden-architect` | Architecture planning + architecture review |
+| `bitwarden-software-engineer` | Implementation |
+| `bitwarden-security-engineer` | Security review |
+| `bitwarden-code-review` | Code quality review |
+| `bitwarden-delivery-tools` | Committing, PRs, preflight, labeling |
+| `bitwarden-atlassian-tools` | Optional — Jira/Confluence fetching |
 
 ## Step 1: Create Team
 
-Use `TeamCreate` to create the team:
-- **Team name**: `pir-{slug}`
-- **Description**: Summary of the task being worked on
+Team name: `pir-{slug}`. Create `.claude/outputs/plans/` and `.claude/outputs/reviews/` directories.
 
-Create the output directories if they don't exist:
-- `.claude/outputs/plans/`
-- `.claude/outputs/reviews/`
-
-## Step 2: Plan Phase (runs once)
-
-Create **4 planning tasks** and **5 standing teammates** (1 implementer + 4 reviewers):
+## Step 2: Plan Phase
 
 ### Planning Tasks
 
 | Task | Subject | Description | blockedBy |
 |------|---------|-------------|-----------|
-| 1 | Analyze requirements | Analyze requirements for: {task description}. Write the requirements specification to `.claude/outputs/plans/{slug}-REQUIREMENTS.md`. Include a high-level work breakdown: epics, user stories, and acceptance criteria. | [] |
-| 2 | Plan architecture and implementation | Read the requirements spec at `.claude/outputs/plans/{slug}-REQUIREMENTS.md`. Design the architecture and produce an implementation plan with phased task breakdown. Write the plan to `.claude/outputs/plans/{slug}-IMPLEMENTATION-PLAN.md`. | ["1"] |
-| 3 | Produce work breakdown | Read the requirements spec at `.claude/outputs/plans/{slug}-REQUIREMENTS.md` and the implementation plan at `.claude/outputs/plans/{slug}-IMPLEMENTATION-PLAN.md`. Consolidate the product analyst's high-level work breakdown (epics, stories, acceptance criteria) with the architect's technical task breakdown (phases, files, dependencies) into a single Jira-ready work breakdown document. Write to `.claude/outputs/plans/{slug}-WORK-BREAKDOWN.md`. | ["1","2"] |
-| 4 | Produce QA handoff | Read the work breakdown at `.claude/outputs/plans/{slug}-WORK-BREAKDOWN.md` and the requirements spec at `.claude/outputs/plans/{slug}-REQUIREMENTS.md`. For each implementation phase/increment in the work breakdown, define: what becomes testable at that point, which acceptance criteria can be verified, test scenarios, regression scope, and any dependencies or environment requirements. Write to `.claude/outputs/plans/{slug}-QA-HANDOFF.md`. | ["3"] |
+| 1 | Analyze requirements | Analyze requirements for: {task description}. Write to `{slug}-REQUIREMENTS.md`. Include high-level work breakdown and **explicitly list which repositories are in scope**. | [] |
+
+After Task #1 completes, the **read the requirements spec** and identify in-scope repos. Then create:
+
+- **One architecture task per repo**: Read the requirements spec, analyze the `{repo}/` directory, design architecture, write to `{slug}-IMPL-{REPO}.md`. Blocked by Task #1. All run in parallel.
+- **WBD task**: Consolidate all `{slug}-IMPL-*.md` plans with the requirements into a Jira-ready work breakdown. Blocked by all architecture tasks.
+- **QA handoff task**: Define testable increments per phase from the WBD. Blocked by WBD.
 
 ### Planning Teammates
 
-Add these teammates to handle the planning tasks. They will be shut down after planning completes:
+Shut down after planning completes.
 
 | Teammate Name | Agent Type | Task | Role |
 |---------------|-----------|------|------|
-| `product-analyst` | `bitwarden-product-analyst:product-analyst` | 1 | Analyze requirements and produce specification |
-| `architect` | `bitwarden-architect:architect` | 2 | Design architecture and produce implementation plan |
-| `wbd-author` | `bitwarden-architect:architect` | 3 | Consolidate high-level and technical breakdowns into Jira-ready WBD |
-| `qa-handoff-author` | `bitwarden-product-analyst:product-analyst` | 4 | Produce QA handoff document with testable increments and scenarios |
+| `product-analyst` | `bitwarden-product-analyst:product-analyst` | 1 | Requirements specification |
+| `architect-{repo}` | `bitwarden-architect:architect` | per-repo | One per in-scope repo. Spawned after Task #1. |
+| `wbd-author` | `bitwarden-architect:architect` | WBD | Consolidate breakdowns |
+| `qa-handoff-author` | `bitwarden-product-analyst:product-analyst` | QA | QA handoff document |
 
 ### Standing Teammates
 
-Also add these teammates at team creation time. They will persist across all implementation phases:
+Persist across all implementation phases. **Implementers are per-repo** (matching the architect pattern). Created after Task #1 identifies in-scope repos.
 
 | Teammate Name | Agent Type | Role |
 |---------------|-----------|------|
-| `implementer` | `bitwarden-software-engineer:bitwarden-software-engineer` | Implement, test, build, preflight, and commit |
-| `requirements-reviewer` | `bitwarden-product-analyst:product-analyst` | Requirements conformance and QA handoff coverage |
+| `implementer-{repo}` | `bitwarden-software-engineer:bitwarden-software-engineer` | One per in-scope repo. Implement, test, build, preflight, commit within `{repo}/`. |
+| `requirements-reviewer` | `bitwarden-product-analyst:product-analyst` | Requirements conformance |
 | `architecture-reviewer` | `bitwarden-architect:architect` | Architecture and pattern adherence |
-| `security-reviewer` | `bitwarden-security-engineer:bitwarden-security-engineer` | Security posture and zero-knowledge compliance |
-| `code-reviewer` | `bitwarden-code-review:bitwarden-code-reviewer` | Code quality and Bitwarden standards |
+| `security-reviewer` | `bitwarden-security-engineer:bitwarden-security-engineer` | Security and zero-knowledge compliance |
+| `code-reviewer` | `bitwarden-code-review:bitwarden-code-reviewer` | Code quality |
 
-**Important**: Instruct all standing teammates (implementer + 4 reviewers) to **wait for explicit instructions from the team lead** before starting any work. They must NOT self-activate based on task dependencies — the team lead controls when each implementation phase begins and when reviewers should start.
+**All standing teammates wait for explicit instructions from the team lead.** They must NOT self-activate.
 
 ### Planning Completion
 
-Once all 4 planning tasks are complete:
-1. **Shut down planning teammates** (`product-analyst`, `architect`, `wbd-author`, `qa-handoff-author`).
-2. **Read the work breakdown** at `.claude/outputs/plans/{slug}-WORK-BREAKDOWN.md`.
-3. **Identify the implementation phases** — extract the ordered list of phases and their scope.
-4. **Present the phase plan** to the user: list all phases with brief descriptions, and ask whether to proceed with all phases sequentially or a subset.
-5. **Proceed to Step 3** (Implementation Loop).
+1. Shut down planning teammates. Standing implementers and reviewers remain.
+2. Read the WBD, extract the ordered phase list.
+3. Present phase plan to user. Proceed to implementation loop.
 
 ## Step 3: Implementation Loop (per phase)
 
-For each implementation phase identified in the work breakdown, execute this cycle:
-
 ### 3a: Dispatch Implementer
 
-1. **Create an implementation task** via `TaskCreate`: "Implement Phase {N}: {phase name}"
-2. **Assign to `implementer`** via `TaskUpdate` with `owner`.
-3. **Send the implementer** a message via `SendMessage` with:
-   - Which phase(s) to implement from the work breakdown
-   - The implementation plan path for reference
-   - Instruction to commit when done and report back
-4. **Wait** for the implementer to report completion.
-5. **Verify** that new commits exist on the branch (check `git log`).
+Each WBD phase targets a specific repo. Dispatch `implementer-{repo}`:
+
+1. Create task: `[{repo}] Implement Phase {N}: {phase name}`
+2. Assign to `implementer-{repo}`.
+3. Send: phase scope, path to `{slug}-IMPL-{REPO}.md`, target repo directory. Instruct to commit when done.
+4. Wait for completion. Verify commits exist.
 
 ### 3b: Dispatch Reviewers
 
-Once the implementer commits:
+**CRITICAL**: Do NOT dispatch reviewers until the implementer has committed.
 
-1. **Create 4 review tasks** via `TaskCreate`, one per reviewer.
-2. **Assign each task** to its reviewer via `TaskUpdate`.
-3. **Send each reviewer** a message via `SendMessage` instructing them to:
-   - Review ONLY the changes from this phase's commit(s) — not previously reviewed code
-   - Write findings to their output file (append the phase number if multiple phases, e.g., `{slug}-REVIEW-CODE-P{N}.md`, or overwrite for single-phase reviews)
-   - Mark their task complete when done
-4. **Wait** for all 4 reviews to complete.
-
-**CRITICAL**: Do NOT allow reviewers to start before the implementer has committed. Reviewers who start early will review stale code and produce invalid findings.
+Create one review task per reviewer. Each reviewer writes findings to their output file. Wait for all 4 to complete.
 
 ### 3c: Consolidate and Fix
 
-Follow the same consolidation and fix cycle as described in Steps 5 and 6 below:
-1. Read all 4 review files, consolidate into a summary.
-2. If critical/important issues exist, send to implementer for fixes (up to 3 rounds).
-3. If clean, proceed to the next phase.
+1. Read all 4 review files. Write a consolidated summary to `{slug}-REVIEW-SUMMARY.md` with **Critical**, **Important**, and **Suggestions** sections. Deduplicate overlapping findings.
+2. If no critical/important issues → proceed to next phase.
+3. If issues exist → send consolidated findings to `implementer-{repo}`. The implementer assesses each finding (fix or dispute with the reviewer). After fixes, re-run reviews. **Max 3 rounds** — after 3 rounds with unresolved issues, escalate to user.
 
 ### 3d: Phase Transition
 
-After a phase's review cycle is clean:
-1. **Print phase completion status**: "Phase {N} complete — {summary of what was built}."
-2. **Optionally create a new branch** for the next phase group (ask user or auto-continue based on mode).
-3. **Proceed to next phase** or, if all phases are done, proceed to Step 7 (Shutdown).
+Print phase completion status. Group tightly coupled phases into a single cycle (max 3 per group). In gated mode, wait for user approval before proceeding.
 
-### Phase Grouping
+## Step 4: Shutdown
 
-Phases can be grouped for a single implement+review cycle when they are closely related and small enough. The team lead should use judgment:
-- Group tightly coupled phases (e.g., "Bank Account form" + "Bank Account view" = one cycle)
-- Keep independent phases separate for cleaner reviews
-- Never group more than 3 phases in a single cycle
-
-## Step 4: Monitor Progress
-
-As team lead, your role during execution is to monitor and coordinate:
-
-1. **Receive automatic notifications** as teammates complete tasks or report issues.
-2. **Print status updates** at each phase transition:
-   - Planning: "Task {N} complete — {artifact} written to {path}"
-   - Implementation: "Phase {N} implemented and committed."
-   - Review: "Phase {N} reviews complete — {summary}."
-3. **Handle `--confirm` mode**: If gated mode is active, present phase output summary and wait for user approval before proceeding to the next phase. In autonomous mode, the loop continues automatically.
-4. **Handle failures**: If a teammate reports a failure, surface details to the user and offer: retry, skip, or abort.
-5. **Handle missing plugins**: If an Agent tool call fails because a plugin is not installed, inform the user which plugin to install and offer to skip that teammate's task.
-
-## Step 5: Consolidate Reviews
-
-After all 4 review tasks for a phase are complete, **you (the team lead) consolidate** the findings:
-
-1. Read all 4 review output files.
-2. Write a consolidated review summary to `.claude/outputs/reviews/{slug}-REVIEW-SUMMARY.md`:
-
-```markdown
-# Review Summary: {feature name}
-
-**Date**: {current date}
-**Phase**: {phase number and name}
-**Round**: {cycle number} of 3
-**Reviewers**: Product Analyst, Architect, Security Engineer, Code Reviewer
-
-## Critical Issues
-[Issues that MUST be addressed before merging — from any reviewer]
-
-## Important Issues
-[Issues that SHOULD be addressed — from any reviewer]
-
-## Suggestions
-[Non-blocking improvements — from any reviewer]
-
-## Per-Reviewer Summaries
-
-### Requirements Conformance (Product Analyst)
-[Brief summary of findings]
-
-### Architecture & Patterns (Architect)
-[Brief summary of findings]
-
-### Security (Security Engineer)
-[Brief summary of findings]
-
-### Code Quality (Code Reviewer)
-[Brief summary of findings]
-```
-
-After writing the summary:
-
-1. Deduplicate overlapping findings — if multiple reviewers flagged the same issue, note which reviewers identified it.
-2. Present the consolidated summary to the user.
-3. If there are **no critical or important issues**, proceed to the next phase (Step 3d) or Step 7 (Shutdown) if all phases are done.
-4. If there **are** critical or important issues, proceed to Step 6 (Review-Fix Cycle).
-
-## Step 6: Review-Fix Cycle (up to 3 rounds per phase)
-
-When reviews surface critical or important issues, the implementer must assess and address them. This cycle can repeat **up to 3 times** before escalating to the user for human intervention.
-
-### 6a: Send Findings to Implementer
-
-Send the consolidated review summary to the `implementer` teammate via `SendMessage`. Instruct the implementer to:
-
-1. **Read** the consolidated review summary and all individual review files.
-2. **Assess** each critical and important finding:
-   - **Legitimate**: Fix the issue in the codebase.
-   - **Disputed**: Send a message to the specific reviewer(s) who raised the finding, explaining why the implementer believes it is a false positive or not applicable. The reviewer should respond with either agreement (finding withdrawn) or a rebuttal with additional evidence.
-3. **After all findings are assessed**: Re-run tests and preflight checks, then commit the fixes.
-4. **Create a new task** via `TaskCreate` for this fix round: "Address review findings (Phase {P}, round {N})" and mark it complete when done.
-5. **Report back** to the team lead with a summary of what was fixed, what was disputed, and the outcomes of any disputes.
-
-### 6b: Re-Review
-
-After the implementer completes the fix round:
-
-1. **Create 4 new review tasks** via `TaskCreate`, one per reviewer.
-2. **Assign and send each reviewer** a message via `SendMessage` instructing them to re-review. Their new review should:
-   - Focus on whether their previous findings were addressed
-   - Check that fixes did not introduce new issues
-   - Write updated findings to the same output file (overwriting the previous round)
-3. **Wait** for all 4 re-reviews to complete.
-4. **Re-consolidate** by repeating Step 5 with the updated review files. Increment the round counter.
-
-### 6c: Cycle Control
-
-- **If no critical/important issues remain**: Exit the cycle and proceed to the next phase or Step 7.
-- **If issues persist and round < 3**: Repeat from Step 6a.
-- **If round reaches 3 and issues still remain**: **Escalate to the user.** Present the outstanding issues, what was attempted across all rounds, and which findings remain disputed. Ask the user to decide: resolve manually, override and proceed, or abort.
-
-### Cycle Status Updates
-
-At each cycle transition, print:
-```
-Review-Fix Cycle: Phase {P}, Round {N}/3
-  - Findings addressed: {count}
-  - Findings disputed: {count} ({count} resolved, {count} upheld)
-  - Remaining critical/important: {count}
-  - Status: {Proceeding to re-review | Escalating to user | All clear}
-```
-
-## Step 7: Shutdown
-
-After all implementation phases are complete (or user decides to stop):
-
-1. **Shutdown all remaining teammates** via `SendMessage` with `shutdown_request` to each by name.
-2. **Delete the team** via `TeamDelete`.
-3. **Present the final summary** listing:
-   - All planning artifact paths (requirements, plan, WBD, QA handoff)
-   - All review file paths (final round per phase)
-   - Consolidated review summary path
-   - Number of phases completed
-   - Number of review-fix cycles per phase
-   - Total commits on the branch
-4. **Suggest next steps**:
-   - If all issues resolved: create a PR via `Skill(bitwarden-delivery-tools:creating-pull-request)`
-   - If user overrode remaining issues: note them as known items for the PR description
-   - Review findings can be used as PR description context
-
-## Guidelines
-
-- **Plan once, implement+review in a loop**: The planning phase produces artifacts that cover ALL phases. Do NOT re-plan for subsequent phases — go straight to implement+review using the existing plans.
-- **Team lead controls reviewer activation**: Reviewers must ONLY start when the team lead explicitly sends them a message after verifying the implementer has committed. Never let reviewers self-activate — they will review stale code.
-- **Use Teams properly**: Create the team, create tasks with dependencies, add all teammates, and let the task system track progress. The team lead manually drives the phase loop.
-- **Standing teammates persist**: The implementer and 4 reviewers stay active across all phases. Only planning teammates are shut down after the plan phase.
-- **Minimal prompts**: Provide teammates only their team name, task number, and output file path. Their AGENT.md definitions handle workflow details.
-- **Status messages**: Print a brief status message when each task completes so the user can track progress.
-- **Missing plugins**: If a marketplace plugin is not installed, tell the user which to install and offer to skip that teammate. Never block the entire pipeline.
-- **Agent failures**: Surface details to the user and offer retry, skip, or abort.
-- **Gated mode (`--confirm`)**: Present phase output summary and wait for user approval before allowing the next phase to proceed.
-- **Autonomous mode (default)**: The loop continues automatically between phases. Only intervene on failures.
-- **Phase grouping**: Use judgment to group closely related phases (max 3) into a single implement+review cycle for efficiency.
+1. Shutdown all remaining teammates. Delete team.
+2. Present final summary: artifact paths, phases completed, review cycles, commits.
+3. Suggest next steps — create PR via `Skill(bitwarden-delivery-tools:creating-pull-request)` if all issues resolved.

--- a/plugins/bitwarden-architect/commands/plan-implement-review/plan-implement-review.md
+++ b/plugins/bitwarden-architect/commands/plan-implement-review/plan-implement-review.md
@@ -1,0 +1,304 @@
+---
+description: End-to-end pipeline orchestrating requirements analysis, architecture planning, implementation, and multi-agent code review via agent team
+argument-hint: <task description, Jira ticket, or Confluence URL> [--confirm]
+---
+
+# Plan-Implement-Review Pipeline
+
+You are the **team lead** for an end-to-end development pipeline. Use the **Claude Agent Teams** feature to create a team, define tasks with dependencies, and add teammates who self-organize around the task list. The task dependency chain drives execution order — teammates claim unblocked tasks, complete them, and check for newly available work.
+
+**Input**: $ARGUMENTS
+
+## Input Parsing
+
+1. **Extract task description**: Strip the `--confirm` flag (if present) from `$ARGUMENTS` to get the raw task description.
+2. **Detect `--confirm` flag**: If `$ARGUMENTS` contains `--confirm`, enable **gated mode** (you must present phase output and get user approval before unblocking the next phase). Otherwise, run in **autonomous mode** (the task dependency chain drives progression automatically).
+3. **Handle empty input**: If `$ARGUMENTS` is empty or only contains `--confirm`, ask the user to provide a task description before proceeding.
+4. **Derive team slug**: Convert the task description to a slug — lowercase, replace spaces and special characters with hyphens, truncate to 40 characters. Example: `"PM-12345 Add biometric timeout"` → `pm-12345-add-biometric-timeout`.
+5. **Define output paths** (using the slug):
+   - `.claude/outputs/plans/{slug}-REQUIREMENTS.md`
+   - `.claude/outputs/plans/{slug}-IMPLEMENTATION-PLAN.md`
+   - `.claude/outputs/plans/{slug}-WORK-BREAKDOWN.md`
+   - `.claude/outputs/plans/{slug}-QA-HANDOFF.md`
+   - `.claude/outputs/reviews/{slug}-REVIEW-REQUIREMENTS.md`
+   - `.claude/outputs/reviews/{slug}-REVIEW-ARCHITECTURE.md`
+   - `.claude/outputs/reviews/{slug}-REVIEW-SECURITY.md`
+   - `.claude/outputs/reviews/{slug}-REVIEW-CODE.md`
+   - `.claude/outputs/reviews/{slug}-REVIEW-SUMMARY.md`
+
+## Pipeline Structure
+
+The pipeline has two major phases: **Plan** (runs once) and **Implement+Review** (loops per phase from the work breakdown). Most features have multiple implementation phases, so looping is the norm.
+
+```
+Plan (once):
+  Requirements → Architecture → Work Breakdown → QA Handoff
+
+Implement+Review (per phase from WBD):
+  Phase 1: Implement → Review → Fix cycle → ✓
+  Phase 2: Implement → Review → Fix cycle → ✓
+  ...
+  Phase N: Implement → Review → Fix cycle → ✓
+
+Shutdown
+```
+
+After the planning phase produces a work breakdown with multiple phases, the team lead drives the implement+review loop — creating new branch per phase group (if desired), dispatching the implementer with phase-specific scope, running the 4-reviewer gauntlet, and iterating until all phases are complete or the user halts.
+
+## Prerequisites
+
+The following marketplace plugins are required for the full pipeline. If a plugin is not installed, inform the user and offer to **skip that teammate** rather than blocking the entire pipeline.
+
+| Plugin | Source | Required For |
+|--------|--------|-------------|
+| `bitwarden-product-analyst` | `bitwarden-marketplace` | Requirements analysis + requirements review |
+| `bitwarden-security-engineer` | `bitwarden-marketplace` | Security review |
+| `bitwarden-code-review` | `bitwarden-marketplace` | Code quality review |
+| `bitwarden-architect` | `bitwarden-marketplace` | Architecture planning + architecture review |
+| `bitwarden-software-engineer` | `bitwarden-marketplace` | Implementation, testing, building, and committing |
+| `bitwarden-atlassian-tools` | `bitwarden-marketplace` | Optional — Jira/Confluence fetching |
+
+All agents are provided by marketplace plugins listed above.
+
+## Step 1: Create Team
+
+Use `TeamCreate` to create the team:
+- **Team name**: `pir-{slug}`
+- **Description**: Summary of the task being worked on
+
+Create the output directories if they don't exist:
+- `.claude/outputs/plans/`
+- `.claude/outputs/reviews/`
+
+## Step 2: Plan Phase (runs once)
+
+Create **4 planning tasks** and **5 standing teammates** (1 implementer + 4 reviewers):
+
+### Planning Tasks
+
+| Task | Subject | Description | blockedBy |
+|------|---------|-------------|-----------|
+| 1 | Analyze requirements | Analyze requirements for: {task description}. Write the requirements specification to `.claude/outputs/plans/{slug}-REQUIREMENTS.md`. Include a high-level work breakdown: epics, user stories, and acceptance criteria. | [] |
+| 2 | Plan architecture and implementation | Read the requirements spec at `.claude/outputs/plans/{slug}-REQUIREMENTS.md`. Design the architecture and produce an implementation plan with phased task breakdown. Write the plan to `.claude/outputs/plans/{slug}-IMPLEMENTATION-PLAN.md`. | ["1"] |
+| 3 | Produce work breakdown | Read the requirements spec at `.claude/outputs/plans/{slug}-REQUIREMENTS.md` and the implementation plan at `.claude/outputs/plans/{slug}-IMPLEMENTATION-PLAN.md`. Consolidate the product analyst's high-level work breakdown (epics, stories, acceptance criteria) with the architect's technical task breakdown (phases, files, dependencies) into a single Jira-ready work breakdown document. Write to `.claude/outputs/plans/{slug}-WORK-BREAKDOWN.md`. | ["1","2"] |
+| 4 | Produce QA handoff | Read the work breakdown at `.claude/outputs/plans/{slug}-WORK-BREAKDOWN.md` and the requirements spec at `.claude/outputs/plans/{slug}-REQUIREMENTS.md`. For each implementation phase/increment in the work breakdown, define: what becomes testable at that point, which acceptance criteria can be verified, test scenarios, regression scope, and any dependencies or environment requirements. Write to `.claude/outputs/plans/{slug}-QA-HANDOFF.md`. | ["3"] |
+
+### Planning Teammates
+
+Add these teammates to handle the planning tasks. They will be shut down after planning completes:
+
+| Teammate Name | Agent Type | Task | Role |
+|---------------|-----------|------|------|
+| `product-analyst` | `bitwarden-product-analyst:product-analyst` | 1 | Analyze requirements and produce specification |
+| `architect` | `bitwarden-architect:architect` | 2 | Design architecture and produce implementation plan |
+| `wbd-author` | `bitwarden-architect:architect` | 3 | Consolidate high-level and technical breakdowns into Jira-ready WBD |
+| `qa-handoff-author` | `bitwarden-product-analyst:product-analyst` | 4 | Produce QA handoff document with testable increments and scenarios |
+
+### Standing Teammates
+
+Also add these teammates at team creation time. They will persist across all implementation phases:
+
+| Teammate Name | Agent Type | Role |
+|---------------|-----------|------|
+| `implementer` | `bitwarden-software-engineer:bitwarden-software-engineer` | Implement, test, build, preflight, and commit |
+| `requirements-reviewer` | `bitwarden-product-analyst:product-analyst` | Requirements conformance and QA handoff coverage |
+| `architecture-reviewer` | `bitwarden-architect:architect` | Architecture and pattern adherence |
+| `security-reviewer` | `bitwarden-security-engineer:bitwarden-security-engineer` | Security posture and zero-knowledge compliance |
+| `code-reviewer` | `bitwarden-code-review:bitwarden-code-reviewer` | Code quality and Bitwarden standards |
+
+**Important**: Instruct all standing teammates (implementer + 4 reviewers) to **wait for explicit instructions from the team lead** before starting any work. They must NOT self-activate based on task dependencies — the team lead controls when each implementation phase begins and when reviewers should start.
+
+### Planning Completion
+
+Once all 4 planning tasks are complete:
+1. **Shut down planning teammates** (`product-analyst`, `architect`, `wbd-author`, `qa-handoff-author`).
+2. **Read the work breakdown** at `.claude/outputs/plans/{slug}-WORK-BREAKDOWN.md`.
+3. **Identify the implementation phases** — extract the ordered list of phases and their scope.
+4. **Present the phase plan** to the user: list all phases with brief descriptions, and ask whether to proceed with all phases sequentially or a subset.
+5. **Proceed to Step 3** (Implementation Loop).
+
+## Step 3: Implementation Loop (per phase)
+
+For each implementation phase identified in the work breakdown, execute this cycle:
+
+### 3a: Dispatch Implementer
+
+1. **Create an implementation task** via `TaskCreate`: "Implement Phase {N}: {phase name}"
+2. **Assign to `implementer`** via `TaskUpdate` with `owner`.
+3. **Send the implementer** a message via `SendMessage` with:
+   - Which phase(s) to implement from the work breakdown
+   - The implementation plan path for reference
+   - Instruction to commit when done and report back
+4. **Wait** for the implementer to report completion.
+5. **Verify** that new commits exist on the branch (check `git log`).
+
+### 3b: Dispatch Reviewers
+
+Once the implementer commits:
+
+1. **Create 4 review tasks** via `TaskCreate`, one per reviewer.
+2. **Assign each task** to its reviewer via `TaskUpdate`.
+3. **Send each reviewer** a message via `SendMessage` instructing them to:
+   - Review ONLY the changes from this phase's commit(s) — not previously reviewed code
+   - Write findings to their output file (append the phase number if multiple phases, e.g., `{slug}-REVIEW-CODE-P{N}.md`, or overwrite for single-phase reviews)
+   - Mark their task complete when done
+4. **Wait** for all 4 reviews to complete.
+
+**CRITICAL**: Do NOT allow reviewers to start before the implementer has committed. Reviewers who start early will review stale code and produce invalid findings.
+
+### 3c: Consolidate and Fix
+
+Follow the same consolidation and fix cycle as described in Steps 5 and 6 below:
+1. Read all 4 review files, consolidate into a summary.
+2. If critical/important issues exist, send to implementer for fixes (up to 3 rounds).
+3. If clean, proceed to the next phase.
+
+### 3d: Phase Transition
+
+After a phase's review cycle is clean:
+1. **Print phase completion status**: "Phase {N} complete — {summary of what was built}."
+2. **Optionally create a new branch** for the next phase group (ask user or auto-continue based on mode).
+3. **Proceed to next phase** or, if all phases are done, proceed to Step 7 (Shutdown).
+
+### Phase Grouping
+
+Phases can be grouped for a single implement+review cycle when they are closely related and small enough. The team lead should use judgment:
+- Group tightly coupled phases (e.g., "Bank Account form" + "Bank Account view" = one cycle)
+- Keep independent phases separate for cleaner reviews
+- Never group more than 3 phases in a single cycle
+
+## Step 4: Monitor Progress
+
+As team lead, your role during execution is to monitor and coordinate:
+
+1. **Receive automatic notifications** as teammates complete tasks or report issues.
+2. **Print status updates** at each phase transition:
+   - Planning: "Task {N} complete — {artifact} written to {path}"
+   - Implementation: "Phase {N} implemented and committed."
+   - Review: "Phase {N} reviews complete — {summary}."
+3. **Handle `--confirm` mode**: If gated mode is active, present phase output summary and wait for user approval before proceeding to the next phase. In autonomous mode, the loop continues automatically.
+4. **Handle failures**: If a teammate reports a failure, surface details to the user and offer: retry, skip, or abort.
+5. **Handle missing plugins**: If an Agent tool call fails because a plugin is not installed, inform the user which plugin to install and offer to skip that teammate's task.
+
+## Step 5: Consolidate Reviews
+
+After all 4 review tasks for a phase are complete, **you (the team lead) consolidate** the findings:
+
+1. Read all 4 review output files.
+2. Write a consolidated review summary to `.claude/outputs/reviews/{slug}-REVIEW-SUMMARY.md`:
+
+```markdown
+# Review Summary: {feature name}
+
+**Date**: {current date}
+**Phase**: {phase number and name}
+**Round**: {cycle number} of 3
+**Reviewers**: Product Analyst, Architect, Security Engineer, Code Reviewer
+
+## Critical Issues
+[Issues that MUST be addressed before merging — from any reviewer]
+
+## Important Issues
+[Issues that SHOULD be addressed — from any reviewer]
+
+## Suggestions
+[Non-blocking improvements — from any reviewer]
+
+## Per-Reviewer Summaries
+
+### Requirements Conformance (Product Analyst)
+[Brief summary of findings]
+
+### Architecture & Patterns (Architect)
+[Brief summary of findings]
+
+### Security (Security Engineer)
+[Brief summary of findings]
+
+### Code Quality (Code Reviewer)
+[Brief summary of findings]
+```
+
+After writing the summary:
+
+1. Deduplicate overlapping findings — if multiple reviewers flagged the same issue, note which reviewers identified it.
+2. Present the consolidated summary to the user.
+3. If there are **no critical or important issues**, proceed to the next phase (Step 3d) or Step 7 (Shutdown) if all phases are done.
+4. If there **are** critical or important issues, proceed to Step 6 (Review-Fix Cycle).
+
+## Step 6: Review-Fix Cycle (up to 3 rounds per phase)
+
+When reviews surface critical or important issues, the implementer must assess and address them. This cycle can repeat **up to 3 times** before escalating to the user for human intervention.
+
+### 6a: Send Findings to Implementer
+
+Send the consolidated review summary to the `implementer` teammate via `SendMessage`. Instruct the implementer to:
+
+1. **Read** the consolidated review summary and all individual review files.
+2. **Assess** each critical and important finding:
+   - **Legitimate**: Fix the issue in the codebase.
+   - **Disputed**: Send a message to the specific reviewer(s) who raised the finding, explaining why the implementer believes it is a false positive or not applicable. The reviewer should respond with either agreement (finding withdrawn) or a rebuttal with additional evidence.
+3. **After all findings are assessed**: Re-run tests and preflight checks, then commit the fixes.
+4. **Create a new task** via `TaskCreate` for this fix round: "Address review findings (Phase {P}, round {N})" and mark it complete when done.
+5. **Report back** to the team lead with a summary of what was fixed, what was disputed, and the outcomes of any disputes.
+
+### 6b: Re-Review
+
+After the implementer completes the fix round:
+
+1. **Create 4 new review tasks** via `TaskCreate`, one per reviewer.
+2. **Assign and send each reviewer** a message via `SendMessage` instructing them to re-review. Their new review should:
+   - Focus on whether their previous findings were addressed
+   - Check that fixes did not introduce new issues
+   - Write updated findings to the same output file (overwriting the previous round)
+3. **Wait** for all 4 re-reviews to complete.
+4. **Re-consolidate** by repeating Step 5 with the updated review files. Increment the round counter.
+
+### 6c: Cycle Control
+
+- **If no critical/important issues remain**: Exit the cycle and proceed to the next phase or Step 7.
+- **If issues persist and round < 3**: Repeat from Step 6a.
+- **If round reaches 3 and issues still remain**: **Escalate to the user.** Present the outstanding issues, what was attempted across all rounds, and which findings remain disputed. Ask the user to decide: resolve manually, override and proceed, or abort.
+
+### Cycle Status Updates
+
+At each cycle transition, print:
+```
+Review-Fix Cycle: Phase {P}, Round {N}/3
+  - Findings addressed: {count}
+  - Findings disputed: {count} ({count} resolved, {count} upheld)
+  - Remaining critical/important: {count}
+  - Status: {Proceeding to re-review | Escalating to user | All clear}
+```
+
+## Step 7: Shutdown
+
+After all implementation phases are complete (or user decides to stop):
+
+1. **Shutdown all remaining teammates** via `SendMessage` with `shutdown_request` to each by name.
+2. **Delete the team** via `TeamDelete`.
+3. **Present the final summary** listing:
+   - All planning artifact paths (requirements, plan, WBD, QA handoff)
+   - All review file paths (final round per phase)
+   - Consolidated review summary path
+   - Number of phases completed
+   - Number of review-fix cycles per phase
+   - Total commits on the branch
+4. **Suggest next steps**:
+   - If all issues resolved: create a PR via `Skill(bitwarden-delivery-tools:creating-pull-request)`
+   - If user overrode remaining issues: note them as known items for the PR description
+   - Review findings can be used as PR description context
+
+## Guidelines
+
+- **Plan once, implement+review in a loop**: The planning phase produces artifacts that cover ALL phases. Do NOT re-plan for subsequent phases — go straight to implement+review using the existing plans.
+- **Team lead controls reviewer activation**: Reviewers must ONLY start when the team lead explicitly sends them a message after verifying the implementer has committed. Never let reviewers self-activate — they will review stale code.
+- **Use Teams properly**: Create the team, create tasks with dependencies, add all teammates, and let the task system track progress. The team lead manually drives the phase loop.
+- **Standing teammates persist**: The implementer and 4 reviewers stay active across all phases. Only planning teammates are shut down after the plan phase.
+- **Minimal prompts**: Provide teammates only their team name, task number, and output file path. Their AGENT.md definitions handle workflow details.
+- **Status messages**: Print a brief status message when each task completes so the user can track progress.
+- **Missing plugins**: If a marketplace plugin is not installed, tell the user which to install and offer to skip that teammate. Never block the entire pipeline.
+- **Agent failures**: Surface details to the user and offer retry, skip, or abort.
+- **Gated mode (`--confirm`)**: Present phase output summary and wait for user approval before allowing the next phase to proceed.
+- **Autonomous mode (default)**: The loop continues automatically between phases. Only intervene on failures.
+- **Phase grouping**: Use judgment to group closely related phases (max 3) into a single implement+review cycle for efficiency.

--- a/plugins/bitwarden-architect/skills/architecting-solutions/SKILL.md
+++ b/plugins/bitwarden-architect/skills/architecting-solutions/SKILL.md
@@ -1,13 +1,15 @@
 ---
 name: architecting-solutions
-description: Principal engineer perspective on architecture, system design, architecture reviews, blast radius assessment, trade-off analysis, and decision-making. Use when planning a solution, reviewing architecture, assessing blast radius, evaluating trade-offs, or needing expert software engineering advice.
+description: Principal engineer perspective on architecture, system design, blast radius assessment, trade-off analysis, and design decisions. Produces architectural thinking, not artifacts — pair with `bitwarden-architect:creating-implementation-plan` when a plan document is required.
+when_to_use: Reasoning about architecture for a Jira ticket, spec, or feature description, Reviewing an architecture proposal, Assessing blast radius before a change, Evaluating trade-offs between competing approaches, Needing expert software engineering judgment on a non-trivial design decision
+argument-hints: Jira ticket key (e.g., PM-XXXX), Confluence page URL or document, Plain-text feature description, Existing architecture proposal to review
 ---
 
 ## Security Mindset
 
 Bitwarden is a password manager — security isn't a feature, it's the product. Every design decision is a security decision.
 
-- **Threat model early.** Before approving an approach, ask: what can an attacker reach from here? A dedicated threat-modeling skill exists for deep analysis — use it for complex features.
+- **Threat model early.** Before approving an approach, ask: what can an attacker reach from here? Invoke `bitwarden-security-engineer:threat-modeling` for new trust boundaries, new PII/secret classes, or anything touching crypto.
 - **Classify data touch points.** Know which fields are encrypted, which are plaintext, and which cross trust boundaries. Never add a new path for sensitive data without encryption at rest and in transit.
 - **Audit trail by default.** Sensitive operations must be observable after the fact. If it can't be audited, it shouldn't ship.
 - **Fail closed.** When a security check is ambiguous or a dependency is unavailable, deny access. Never default to permissive.
@@ -45,3 +47,12 @@ Bitwarden is a password manager — security isn't a feature, it's the product. 
 - Missing test coverage for new code paths
 - Security shortcuts in the name of velocity
 - Refactors bundled with feature work without explicit scope approval
+
+## Composition
+
+This skill answers *what to worry about*. Reach for adjacent skills via the `Skill` tool when the work crosses their domain:
+
+- `bitwarden-architect:creating-implementation-plan` — when the output needs to be a structured plan document ready for implementer handoff.
+- `bitwarden-security-engineer:threat-modeling` — new trust boundaries, new PII/secret classes, crypto changes.
+- `bitwarden-security-engineer:reviewing-security-architecture` — authentication, authorization, encryption design review.
+- `bitwarden-software-engineer:writing-server-code`, `bitwarden-software-engineer:writing-client-code`, `bitwarden-software-engineer:writing-database-queries`, `bitwarden-software-engineer:implementing-dapper-queries`, `bitwarden-software-engineer:implementing-ef-core` — language and repo conventions for the target stack.

--- a/plugins/bitwarden-architect/skills/architecting-solutions/SKILL.md
+++ b/plugins/bitwarden-architect/skills/architecting-solutions/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: architecting-solutions
+description: Bitwarden solution architecture process — context discovery, requirements refinement, gap analysis, architecture design, and deliverable production. Use when planning a solution, reviewing architecture, assessing blast radius, or evaluating trade-offs in any Bitwarden repository. Not for writing code — for deciding what to build and how the parts connect.
+---
+
+## Step 1: Context Discovery
+
+Before any planning, orient yourself in the target repository:
+
+1. **Read the repo's CLAUDE.md** — learn architecture constraints, security rules, code organization, and available skills from the **Skills & Commands** table.
+
+2. **Read architecture documentation** referenced in CLAUDE.md — follow whatever links or file references it provides.
+
+3. **Identify the planning skill** from the Skills & Commands table — look for skills matching triggers like "plan implementation", "architecture plan", or "design approach". **Use the `Skill` tool to invoke it by name** (e.g., `Skill("planning-android-implementation")`). Do NOT read the SKILL.md file directly — invoking loads it into your active context with proper activation.
+
+4. **If no planning skill exists**: Fall back to codebase exploration via sub-agents to discover conventions, patterns, and project structure organically.
+
+---
+
+## Step 2: Requirements Refinement
+
+Parse the requirements and actively look for gaps — focus on Bitwarden-specific concerns:
+
+- Missing security or zero-knowledge implications
+- Unspecified API contracts or SDK interactions — especially V+/-2 compatibility
+- Undefined multi-account or account-switching behavior
+- Missing app extension / module boundary considerations
+- Impact on self-hosted deployments and the version matrix
+
+If a requirements-refinement skill exists in the repo, **use the `Skill` tool to invoke it by name**.
+
+Produce a structured specification covering: summary, affected modules, functional requirements, non-functional requirements, open questions, and assumptions.
+
+---
+
+## Step 3: Technical Gap Analysis
+
+Evaluate each item and note which are relevant — do not include items that clearly don't apply:
+
+- [ ] Zero-knowledge / encryption implications
+- [ ] Authentication / authorization changes
+- [ ] Multi-account / account-switching impact
+- [ ] Multi-client impact (web, browser, desktop, CLI, self-hosted)
+- [ ] App extension / module boundary impact
+- [ ] SDK dependency or API contract changes (V+/-2 compatibility)
+- [ ] Dual data-access parity (both database backends, if applicable)
+- [ ] Data migration or schema changes
+- [ ] Performance / memory implications
+- [ ] Offline / network failure behavior
+
+You own **technical** gaps (security, platform constraints, SDK, extensions). Product/UX gaps are the product analyst's domain.
+
+---
+
+## Step 4: Architecture Design
+
+1. **Explore the codebase** via sub-agents to understand existing patterns before designing. Never assume file locations or implementations.
+
+2. **Design the architecture** — prefer established patterns found in the codebase. Flag cases where a new pattern might be genuinely needed (rare). Reference specific existing files as implementation guides.
+
+3. Organize work into logical, dependency-ordered phases. Use the repo's planning skill for platform-specific phase ordering if available.
+
+---
+
+## Bitwarden-Specific Constraints
+
+### Security Mindset
+
+Bitwarden is a password manager — security isn't a feature, it's the product.
+
+- **Threat model early.** Before approving an approach, ask: what can an attacker reach from here? Use the threat-modeling skill for complex features.
+- **Classify data touch points.** Know which fields are encrypted, which are plaintext, and which cross trust boundaries. Never add a new path for sensitive data without encryption at rest and in transit.
+
+### Platform Constraints
+
+- **Version matrix (V +/- 2):** The server must support clients up to 2 major versions behind. Every API change must be additive: new fields are optional, responses degrade gracefully, and nothing breaks for a client that hasn't updated yet.
+- **No formal API versioning:** Breaking changes are actively discouraged. API models trend toward optional-everywhere to preserve backwards compatibility. Don't add required fields to existing endpoints.
+- **Self-hosted constraint:** Features must degrade gracefully for self-hosted customers who may run older versions or different infrastructure.
+
+### Judgment
+
+- **Complement existing patterns.** New code should work alongside what's already there. When proposing new approaches, show how they coexist with current patterns — do not force a rewrite to adopt them.
+- **Document tech debt, don't silently fix it.** Unscoped refactors create unwanted risk. Identify the finding and report it to the user.
+
+### Red Flags to Surface
+
+- Silent behavior changes in shared libraries (`libs/common`, `src/Core`)
+- Refactors bundled with feature work without explicit scope approval
+- Security shortcuts in the name of velocity
+
+---
+
+## Deliverables
+
+### 1. Implementation Plan (`{slug}-IMPLEMENTATION-PLAN.md`)
+
+```
+# Implementation Plan: [Feature Name]
+
+## Refined Requirements
+### Summary
+### Functional Requirements
+### Non-Functional Requirements
+### Assumptions
+### Open Questions (if any — request answers from user before proceeding)
+
+## Technical Gap Analysis
+[Security, platform constraints, SDK, multi-account, extensions — only items that apply]
+
+## Architecture Design
+### Affected Components
+### New Interfaces & Implementations
+### Data Flow Diagram (text-based)
+
+## Phased Implementation Plan
+### Phase 1: [Name]
+- Task 1.1: [concrete, actionable task]
+  - Files: [paths]
+  - Depends on: [nothing | task X.Y]
+  - Acceptance: [how to verify this task is done]
+### Phase 2: [Name]
+...
+
+## File Manifest
+### New Files
+### Modified Files
+
+## Risk & Dependency Notes
+
+## Handoff Notes for Implementer
+```
+
+### 2. Work Breakdown Document (`{slug}-WORK-BREAKDOWN.md`)
+
+When consolidating with a product analyst's high-level breakdown: merge their epics/stories/acceptance criteria with your technical task breakdown into Jira-ready tasks.
+
+### 3. Architecture Review
+
+When reviewing implementation against a plan: verify adherence to the architecture design, pattern selection, and repo conventions.
+
+---
+
+## Output Location
+
+Write artifacts to `${CLAUDE_PLUGIN_DATA}/plans/`:
+- `${CLAUDE_PLUGIN_DATA}/plans/{slug}-IMPLEMENTATION-PLAN.md`
+- `${CLAUDE_PLUGIN_DATA}/plans/{slug}-WORK-BREAKDOWN.md`
+
+Create the output directory if it doesn't exist.

--- a/plugins/bitwarden-architect/skills/creating-implementation-plan/SKILL.md
+++ b/plugins/bitwarden-architect/skills/creating-implementation-plan/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: creating-implementation-plan
+description: This skill should be used when the user asks to "create an implementation plan", "produce a plan for PM-XXXX", "write an implementation plan", "break this feature into phases", or otherwise requests a structured plan artifact ready for handoff to an implementer. Produces a markdown plan with pattern anchors, blast radius, phased task breakdown, risks, and open questions.
+when_to_use: Architectural decisions are made and a structured plan artifact is required, Handoff to an implementer is imminent, Converting a refined spec into a phased engineering plan, Documenting a planned change for review before code lands
+argument-hints: Jira ticket key (e.g., PM-XXXX), Architectural decisions or design notes from prior reasoning, Target repository slug (server, clients, sdk-internal, android, etc.), Confluence page URL or plain-text feature description
+---
+
+## Scope
+
+This skill produces a single artifact: an implementation plan written to `${CLAUDE_PLUGIN_DATA}/plans/{slug}-IMPLEMENTATION-PLAN.md`. It does not do architectural thinking — pair with `bitwarden-architect:architecting-solutions` upstream if principles, blast radius, and trade-offs have not yet been reasoned through.
+
+Derive the slug from the ticket and target (e.g., `pm-32009-new-item-types-server`). Create the output directory if it does not exist.
+
+## Discover Per-Repo Planning Skills First
+
+Before using the default template, look in `<repo>/.claude/skills/` for a planning-related skill (anything matching triggers like "plan implementation", "architecture design", or similar). If one exists, defer the artifact shape to it — invoke via the `Skill` tool if available, otherwise read the `SKILL.md` directly. Per-repo planning skills own platform-specific phase conventions, test commands, and "definition of done" for their repo.
+
+Use the template below only when no per-repo planning skill exists.
+
+## Default Template
+
+```markdown
+# Implementation Plan: [Feature Name]
+
+## Current State
+What's already shipped (verify against the working tree, not the ticket). Pattern anchors with `file:line`.
+
+## Blast Radius
+Affected modules — Primary / Secondary / No-change-verified.
+
+## Design
+Type model, interfaces, data flow.
+
+## Phases
+Dependency-ordered, each one PR. Per phase: tasks, files, acceptance.
+
+## Risks & Open Questions
+Likelihood × impact + mitigation. Tech debt surfaced (don't silently fix). Questions for the human (don't invent answers).
+```
+
+## Section Guidance
+
+- **Current State:** Read the working tree, not the ticket description. Tickets overrun what's actually shipped. Cite concrete `file:line` anchors for every pattern the plan will mirror.
+- **Blast Radius:** Group as Primary (must change), Secondary (verify, likely no change), No-change-verified (confirmed via grep or read). Naming the "no change" set is load-bearing — it tells reviewers what was considered.
+- **Design:** Show how new code coexists with existing patterns. Text-based data-flow diagrams are fine. Do not invent new abstractions where three similar lines would do.
+- **Phases:** Each phase should be independently reviewable as a single PR. Per phase: tasks, files touched, acceptance criteria. Phase 0 is typically pre-flight (verify assumptions, confirm upstream artifacts, regenerate bindings).
+- **Risks & Open Questions:** Include likelihood × impact + mitigation. Separate "tech debt surfaced" (flag, don't fix) from "risks" (must mitigate). Open questions go to the human — never invent answers.
+
+## Companion Skills
+
+Compose with adjacent skills when the plan crosses their domain:
+
+- `bitwarden-architect:architecting-solutions` — architectural thinking (principles, blast radius heuristics, security mindset). Invoke upstream if not already done.
+- `bitwarden-product-analyst:requirements-elicitation` — when requirements are ambiguous or the ticket lacks acceptance criteria.
+- `bitwarden-product-analyst:work-breakdown` — to convert the plan's phases into Jira-ready tasks.
+- `bitwarden-security-engineer:threat-modeling` — new trust boundaries, new PII/secret classes, crypto changes.
+- `bitwarden-software-engineer:writing-server-code`, `bitwarden-software-engineer:writing-client-code`, `bitwarden-software-engineer:writing-database-queries`, `bitwarden-software-engineer:implementing-dapper-queries`, `bitwarden-software-engineer:implementing-ef-core` — language and repo conventions when the plan targets code sites in those stacks.

--- a/plugins/bitwarden-architect/skills/creating-implementation-plan/SKILL.md
+++ b/plugins/bitwarden-architect/skills/creating-implementation-plan/SKILL.md
@@ -1,21 +1,19 @@
 ---
 name: creating-implementation-plan
 description: This skill should be used when the user asks to "create an implementation plan", "produce a plan for PM-XXXX", "write an implementation plan", "break this feature into phases", or otherwise requests a structured plan artifact ready for handoff to an implementer. Produces a markdown plan with pattern anchors, blast radius, phased task breakdown, risks, and open questions.
-when_to_use: Architectural decisions are made and a structured plan artifact is required, Handoff to an implementer is imminent, Converting a refined spec into a phased engineering plan, Documenting a planned change for review before code lands
+when_to_use: Use after `bitwarden-architect:architecting-solutions`, or when a solution has already been identified and needs to be planned. Architectural decisions are made and a structured plan artifact is required, Handoff to an implementer is imminent, Converting a refined spec into a phased engineering plan
 argument-hints: Jira ticket key (e.g., PM-XXXX), Architectural decisions or design notes from prior reasoning, Target repository slug (server, clients, sdk-internal, android, etc.), Confluence page URL or plain-text feature description
 ---
 
 ## Scope
 
-This skill produces a single artifact: an implementation plan written to `${CLAUDE_PLUGIN_DATA}/plans/{slug}-IMPLEMENTATION-PLAN.md`. It does not do architectural thinking — pair with `bitwarden-architect:architecting-solutions` upstream if principles, blast radius, and trade-offs have not yet been reasoned through.
+This skill produces one artifact: an implementation plan at `${CLAUDE_PLUGIN_DATA}/plans/{slug}-IMPLEMENTATION-PLAN.md`. Derive the slug from ticket + target (e.g., `pm-32009-new-item-types-server`). Create the output directory if needed.
 
-Derive the slug from the ticket and target (e.g., `pm-32009-new-item-types-server`). Create the output directory if it does not exist.
+It does not do architectural thinking. If the design has not yet been reasoned through — principles, blast radius, trade-offs — invoke `bitwarden-architect:architecting-solutions` first and carry its conclusions into the plan.
 
-## Discover Per-Repo Planning Skills First
+## Per-Repo Planning Skills Take Precedence
 
-Before using the default template, look in `<repo>/.claude/skills/` for a planning-related skill (anything matching triggers like "plan implementation", "architecture design", or similar). If one exists, defer the artifact shape to it — invoke via the `Skill` tool if available, otherwise read the `SKILL.md` directly. Per-repo planning skills own platform-specific phase conventions, test commands, and "definition of done" for their repo.
-
-Use the template below only when no per-repo planning skill exists.
+Before using the default template, look in `<repo>/.claude/skills/` for a planning-related skill. If one exists, defer the artifact shape to it — invoke via the `Skill` tool if available, otherwise read the `SKILL.md` directly. Per-repo planning skills own platform-specific phase conventions, test commands, and definition-of-done.
 
 ## Default Template
 
@@ -38,20 +36,6 @@ Dependency-ordered, each one PR. Per phase: tasks, files, acceptance.
 Likelihood × impact + mitigation. Tech debt surfaced (don't silently fix). Questions for the human (don't invent answers).
 ```
 
-## Section Guidance
+## Downstream Handoff
 
-- **Current State:** Read the working tree, not the ticket description. Tickets overrun what's actually shipped. Cite concrete `file:line` anchors for every pattern the plan will mirror.
-- **Blast Radius:** Group as Primary (must change), Secondary (verify, likely no change), No-change-verified (confirmed via grep or read). Naming the "no change" set is load-bearing — it tells reviewers what was considered.
-- **Design:** Show how new code coexists with existing patterns. Text-based data-flow diagrams are fine. Do not invent new abstractions where three similar lines would do.
-- **Phases:** Each phase should be independently reviewable as a single PR. Per phase: tasks, files touched, acceptance criteria. Phase 0 is typically pre-flight (verify assumptions, confirm upstream artifacts, regenerate bindings).
-- **Risks & Open Questions:** Include likelihood × impact + mitigation. Separate "tech debt surfaced" (flag, don't fix) from "risks" (must mitigate). Open questions go to the human — never invent answers.
-
-## Companion Skills
-
-Compose with adjacent skills when the plan crosses their domain:
-
-- `bitwarden-architect:architecting-solutions` — architectural thinking (principles, blast radius heuristics, security mindset). Invoke upstream if not already done.
-- `bitwarden-product-analyst:requirements-elicitation` — when requirements are ambiguous or the ticket lacks acceptance criteria.
-- `bitwarden-product-analyst:work-breakdown` — to convert the plan's phases into Jira-ready tasks.
-- `bitwarden-security-engineer:threat-modeling` — new trust boundaries, new PII/secret classes, crypto changes.
-- `bitwarden-software-engineer:writing-server-code`, `bitwarden-software-engineer:writing-client-code`, `bitwarden-software-engineer:writing-database-queries`, `bitwarden-software-engineer:implementing-dapper-queries`, `bitwarden-software-engineer:implementing-ef-core` — language and repo conventions when the plan targets code sites in those stacks.
+When phases are ready to become tickets, invoke `bitwarden-architect:creating-work-breakdown`.

--- a/plugins/bitwarden-architect/skills/creating-work-breakdown/SKILL.md
+++ b/plugins/bitwarden-architect/skills/creating-work-breakdown/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: creating-work-breakdown
+description: This skill should be used when the user asks to "break this plan into tickets", "create a work breakdown", "generate Jira tasks from the plan", "prepare tickets for this feature", or otherwise requests a ticket-ready decomposition of an implementation plan. Converts an implementation plan's phases into discrete, dependency-ordered tasks with file touchpoints and acceptance criteria.
+when_to_use: Use after `bitwarden-architect:creating-implementation-plan`, or when an implementation plan already exists and needs to be split into tickets. Preparing work for sprint planning or Jira import, Handing phases off to multiple implementers, Capturing dependencies between tasks explicitly
+argument-hints: Path to an existing implementation plan (e.g., ${CLAUDE_PLUGIN_DATA}/plans/pm-32009-new-item-types-server-IMPLEMENTATION-PLAN.md), Jira epic or parent ticket key, Target repository slug, Optional output filename (defaults to {slug}-WORK-BREAKDOWN.md)
+---
+
+## Scope
+
+This skill produces one artifact: a work-breakdown document under `${CLAUDE_PLUGIN_DATA}/plans/`. If the user supplies an output filename, use it verbatim. Otherwise default to `{slug}-WORK-BREAKDOWN.md`, reusing the same slug as the corresponding implementation plan so the two files pair up.
+
+It does not do implementation planning. If no plan exists yet, invoke `bitwarden-architect:creating-implementation-plan` first.
+
+## Template
+
+```markdown
+# Work Breakdown: [Feature Name]
+
+**Plan:** `{slug}-IMPLEMENTATION-PLAN.md`
+**Parent ticket:** [Jira epic or parent, if known]
+
+## Task: [Short imperative title]
+**Phase:** [Phase N from the plan]
+**Files:** [paths that this task touches]
+**Depends on:** [task titles or "none"]
+**Acceptance:**
+- [ ] [observable, verifiable criterion]
+- [ ] [another criterion]
+**Notes:** [optional — non-obvious context, risks surfaced during decomposition]
+
+## Task: [next]
+...
+```
+
+## Decomposition Rules
+
+- **One task, one PR.** If a task is too large to review in a single PR, split it.
+- **Order by dependency.** A task that depends on another must come later in the list. Make the dependency explicit in the `Depends on` field.
+- **Every task cites files.** "Updates the thing" is not a task. "Updates `src/Foo/Bar.cs:42` and its tests" is.
+- **Acceptance criteria are observable.** Prefer "unit test X passes", "endpoint Y returns 200", "flag Z toggles feature" over "works correctly".
+- **Preserve the plan's phase boundaries.** A task belongs to exactly one phase. If decomposition reveals a phase that should split, flag it as a plan-level issue rather than papering over it here.
+- **Inherit risks from the plan.** Do not re-enumerate plan-level risks per task. If a risk is task-specific (e.g., "depends on external SDK release"), note it in `Notes`.

--- a/plugins/bitwarden-delivery-tools/.claude-plugin/plugin.json
+++ b/plugins/bitwarden-delivery-tools/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "bitwarden-delivery-tools",
+  "version": "0.1.0",
+  "description": "Generic delivery workflow skills for committing, PR creation, preflight checks, and change labeling across any Bitwarden repository.",
+  "author": {
+    "name": "Bitwarden",
+    "url": "https://github.com/bitwarden"
+  },
+  "homepage": "https://github.com/bitwarden/ai-marketplace/tree/main/plugins/bitwarden-delivery-tools",
+  "repository": "https://github.com/bitwarden/ai-marketplace",
+  "keywords": ["delivery", "commit", "pull-request", "preflight", "labeling"]
+}

--- a/plugins/bitwarden-delivery-tools/.claude-plugin/plugin.json
+++ b/plugins/bitwarden-delivery-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bitwarden-delivery-tools",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Generic delivery workflow skills for committing, PR creation, preflight checks, and change labeling across any Bitwarden repository.",
   "author": {
     "name": "Bitwarden",

--- a/plugins/bitwarden-delivery-tools/CHANGELOG.md
+++ b/plugins/bitwarden-delivery-tools/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the `bitwarden-delivery-tools` plugin will be documented 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.0] - 2026-04-08
+## [1.0.0] - 2026-04-08
 
 ### Added
 

--- a/plugins/bitwarden-delivery-tools/CHANGELOG.md
+++ b/plugins/bitwarden-delivery-tools/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to the `bitwarden-delivery-tools` plugin will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2026-04-08
+
+### Added
+
+- Generic `committing-changes` skill for commit message format and staging workflow
+- Generic `creating-pull-request` skill for PR creation and draft workflow
+- Generic `labeling-changes` skill for conventional commit type keywords and label mapping
+- Generic `perform-preflight` skill for pre-commit quality gate checklist
+- All skills are platform-agnostic and reference the repo's CLAUDE.md for platform-specific details

--- a/plugins/bitwarden-delivery-tools/README.md
+++ b/plugins/bitwarden-delivery-tools/README.md
@@ -1,0 +1,24 @@
+# Bitwarden Delivery Tools
+
+Generic delivery workflow skills for committing, PR creation, preflight checks, and change labeling across any Bitwarden repository.
+
+## Overview
+
+These skills define the delivery **process** — commit formats, PR workflows, quality gates, and labeling conventions. Platform-specific details (build commands, lint tools, test runners) are discovered dynamically from each repo's CLAUDE.md.
+
+## Skills
+
+| Skill | Triggers | Purpose |
+|-------|---------|---------|
+| `committing-changes` | "commit", "stage changes" | Commit message format, staging best practices |
+| `creating-pull-request` | "create PR", "open PR" | PR title/body format, draft workflow, AI review labels |
+| `labeling-changes` | "label", "change type" | Conventional commit type keywords, CI label mapping |
+| `perform-preflight` | "preflight", "self review" | Pre-commit quality gate checklist |
+
+## Design Principle
+
+Each skill owns the **workflow** (what steps to follow, what format to use). The repo's CLAUDE.md owns the **platform specifics** (which linter to run, which test command to use, which security rules apply). This separation allows the same skills to work across Android, iOS, Server, SDK, and Clients repos.
+
+## Installation
+
+Install via the Bitwarden AI Marketplace.

--- a/plugins/bitwarden-delivery-tools/skills/committing-changes/SKILL.md
+++ b/plugins/bitwarden-delivery-tools/skills/committing-changes/SKILL.md
@@ -16,12 +16,26 @@ description: Git commit conventions and workflow for Bitwarden repositories. Use
 ### Rules
 
 1. **Ticket prefix**: Always include `[PM-XXXXX]` matching the Jira ticket
-2. **Type keyword**: Include a conventional commit type after the ticket prefix — **use the `labeling-changes` skill** (invoke via the Skill tool) for the full type keyword table and selection guidance
-3. **Imperative mood**: "Add feature" not "Added feature" or "Adds feature"
-4. **Short summary**: Under 72 characters for the first line
-5. **Body**: Explain the "why" not the "what" — the diff shows the what
+2. **Type keyword**: Select from the table below. The keyword drives automatic `t:` label assignment via CI (`.github/scripts/label-pr.py` reads `.github/label-pr.json`). CI matches `<type>:` or `<type>(` in the lowercased title.
 
-### Example
+| Type | Label | Use for |
+|------|-------|---------|
+| `feat` | `t:feature` | New features or functionality |
+| `fix` | `t:bug` | Bug fixes |
+| `refactor` | `t:tech-debt` | Code restructuring without behavior change |
+| `chore` | `t:tech-debt` | Maintenance, cleanup, minor tweaks |
+| `test` | `t:tech-debt` | Adding or updating tests |
+| `perf` | `t:tech-debt` | Performance improvements |
+| `docs` | `t:docs` | Documentation changes |
+| `ci` / `build` | `t:ci` | CI/CD and build system changes |
+| `deps` | `t:deps` | Dependency updates |
+| `llm` | `t:llm` | LLM/Claude configuration changes |
+| `breaking` | `t:breaking-change` | Breaking changes requiring migration |
+| `misc` | `t:misc` | Changes that do not fit other categories |
+
+CI also accepts aliases (e.g., `revert`, `bugfix`, `cleanup`). See `.github/label-pr.json` for the full mapping. **If the type cannot be confidently determined, ask the user.**
+
+### Examples
 
 ```
 [PM-12345] feat: Add biometric unlock timeout configuration
@@ -30,9 +44,18 @@ Users reported confusion about when biometric prompts appear.
 This adds a configurable timeout setting to the security preferences.
 ```
 
+Ambiguous cases — choosing between similar types:
+```
+# Refactor that also fixes a bug? Use the primary intent:
+[PM-12345] fix: Resolve null pointer in vault sync retry logic
+
+# Test-only change:
+[PM-12345] test: Add unit tests for biometric timeout edge cases
+```
+
 ### Followup Commits
 
-Only the first commit on a branch needs the full format (ticket prefix, type keyword, body). Subsequent commits — whether addressing review feedback, making intermediate changes, or iterating locally — can use a short, descriptive summary with no prefix or body required.
+Only the first commit on a branch needs the full format (ticket prefix, type keyword, body). Subsequent commits can use a short, descriptive summary with no prefix or body required.
 
 ```
 Update error handling in login flow
@@ -40,36 +63,6 @@ Update error handling in login flow
 
 ---
 
-## Pre-Commit Checklist
+## Pre-Commit Quality Gate
 
-Consult the repo's CLAUDE.md for platform-specific build and lint commands. At minimum, before staging and committing:
-
-1. **Run affected tests** — use the repo's build/test skill if available
-2. **Check lint** — run the repo's linter on changed files
-3. **Review staged changes**: `git diff --staged` — verify no unintended modifications
-4. **Verify no secrets**: No API keys, tokens, passwords, or `.env` files staged
-5. **Verify no generated files**: No build outputs, IDE-specific changes, or generated code
-
----
-
-## What NOT to Commit
-
-- `.env` files or config files with real tokens/credentials
-- Signing keys or keystores
-- Build outputs (platform-specific — check `.gitignore`)
-- IDE-specific files (`.idea/` changes, `*.iml`, `.xcuserdata/`, etc.)
-- Large binary files
-
----
-
-## Staging Best Practices
-
-- **Stage specific files** by name rather than `git add -A` or `git add .`
-- Put each file path on its own line for readability:
-  ```bash
-  git add \
-    path/to/first/File \
-    path/to/second/File
-  ```
-- Review each file being staged to avoid accidentally including sensitive data
-- Use `git status` (without `-uall` flag) to see the working tree state
+Before staging, run the `perform-preflight` skill for the full quality gate checklist (tests, lint, security, architecture). Consult the repo's CLAUDE.md for platform-specific build and lint commands.

--- a/plugins/bitwarden-delivery-tools/skills/committing-changes/SKILL.md
+++ b/plugins/bitwarden-delivery-tools/skills/committing-changes/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: committing-changes
+description: Git commit conventions and workflow for Bitwarden repositories. Use when committing code, writing commit messages, or preparing changes for commit. Triggered by "commit", "git commit", "commit message", "prepare commit", "stage changes".
+---
+
+# Git Commit Conventions
+
+## Commit Message Format
+
+```
+[PM-XXXXX] <type>: <imperative summary>
+
+<optional body explaining why, not what>
+```
+
+### Rules
+
+1. **Ticket prefix**: Always include `[PM-XXXXX]` matching the Jira ticket
+2. **Type keyword**: Include a conventional commit type after the ticket prefix — **use the `labeling-changes` skill** (invoke via the Skill tool) for the full type keyword table and selection guidance
+3. **Imperative mood**: "Add feature" not "Added feature" or "Adds feature"
+4. **Short summary**: Under 72 characters for the first line
+5. **Body**: Explain the "why" not the "what" — the diff shows the what
+
+### Example
+
+```
+[PM-12345] feat: Add biometric unlock timeout configuration
+
+Users reported confusion about when biometric prompts appear.
+This adds a configurable timeout setting to the security preferences.
+```
+
+### Followup Commits
+
+Only the first commit on a branch needs the full format (ticket prefix, type keyword, body). Subsequent commits — whether addressing review feedback, making intermediate changes, or iterating locally — can use a short, descriptive summary with no prefix or body required.
+
+```
+Update error handling in login flow
+```
+
+---
+
+## Pre-Commit Checklist
+
+Consult the repo's CLAUDE.md for platform-specific build and lint commands. At minimum, before staging and committing:
+
+1. **Run affected tests** — use the repo's build/test skill if available
+2. **Check lint** — run the repo's linter on changed files
+3. **Review staged changes**: `git diff --staged` — verify no unintended modifications
+4. **Verify no secrets**: No API keys, tokens, passwords, or `.env` files staged
+5. **Verify no generated files**: No build outputs, IDE-specific changes, or generated code
+
+---
+
+## What NOT to Commit
+
+- `.env` files or config files with real tokens/credentials
+- Signing keys or keystores
+- Build outputs (platform-specific — check `.gitignore`)
+- IDE-specific files (`.idea/` changes, `*.iml`, `.xcuserdata/`, etc.)
+- Large binary files
+
+---
+
+## Staging Best Practices
+
+- **Stage specific files** by name rather than `git add -A` or `git add .`
+- Put each file path on its own line for readability:
+  ```bash
+  git add \
+    path/to/first/File \
+    path/to/second/File
+  ```
+- Review each file being staged to avoid accidentally including sensitive data
+- Use `git status` (without `-uall` flag) to see the working tree state

--- a/plugins/bitwarden-delivery-tools/skills/creating-pull-request/SKILL.md
+++ b/plugins/bitwarden-delivery-tools/skills/creating-pull-request/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: creating-pull-request
+description: Pull request creation workflow for Bitwarden repositories. Use when creating PRs, writing PR descriptions, or preparing branches for review. Triggered by "create PR", "pull request", "open PR", "gh pr create", "PR description".
+---
+
+# Create Pull Request
+
+## PR Title Format
+
+```
+[PM-XXXXX] <type>: <short imperative summary>
+```
+
+**Examples:**
+- `[PM-12345] feat: Add autofill support for passkeys`
+- `[PM-12345] fix: Resolve crash during vault sync`
+- `[PM-12345] refactor: Simplify authentication flow`
+
+**Rules:**
+- Include Jira ticket prefix
+- Keep under 70 characters total
+- Use imperative mood in the summary
+
+**Type keywords** (triggers automatic `t:` label via CI):
+
+**Use the `labeling-changes` skill** (invoke via the Skill tool) for the full type keyword table and selection guidance.
+
+---
+
+## PR Body Template
+
+**IMPORTANT:** Always follow the repo's PR template at `.github/PULL_REQUEST_TEMPLATE.md`. If no template exists, use this structure:
+
+```markdown
+## Type of change
+<!-- feat / fix / refactor / chore / etc. -->
+
+## Objective
+<!-- What does this PR accomplish? Link Jira ticket. -->
+
+## Code changes
+<!-- Bullet list of key changes. -->
+
+## Before you submit
+- [ ] Tests added/updated
+- [ ] Lint/format passing
+- [ ] Self-reviewed changes
+```
+
+Delete the Screenshots section entirely if there are no UI changes.
+
+---
+
+## Pre-PR Checklist
+
+1. **All tests pass** — consult CLAUDE.md or the repo's build/test skill for the correct test commands
+2. **Lint clean** — consult CLAUDE.md for the repo's lint command
+3. **Self-review done** — use the `perform-preflight` skill
+4. **No unintended changes**: Check `git diff origin/main...HEAD` for unexpected files
+5. **Branch up to date**: Rebase on `main` if needed
+
+---
+
+## Creating the PR
+
+```bash
+# Ensure branch is pushed
+git push -u origin <branch-name>
+
+# Create PR as draft by default (body follows .github/PULL_REQUEST_TEMPLATE.md)
+gh pr create --draft --title "[PM-XXXXX] feat: Short summary" --body "<fill in from PR template>"
+```
+
+**Default to draft PRs.** Only create a non-draft (ready for review) PR if the user explicitly requests it.
+
+---
+
+## AI Review Label
+
+Before running `gh pr create`, **always** use the `AskUserQuestion` tool to ask whether to add an AI review label:
+
+- **Question**: "Would you like to add an AI review label to this PR?"
+- **Options**: `ai-review-vnext`, `ai-review`, `No label`
+
+If the user selects a label, include it via the `--label` flag:
+
+```bash
+gh pr create --draft --label "ai-review-vnext" --title "..." --body "..."
+```
+
+---
+
+## Base Branch
+
+- Default target: `main`
+- Check with team if targeting a feature branch instead

--- a/plugins/bitwarden-delivery-tools/skills/creating-pull-request/SKILL.md
+++ b/plugins/bitwarden-delivery-tools/skills/creating-pull-request/SKILL.md
@@ -11,25 +11,33 @@ description: Pull request creation workflow for Bitwarden repositories. Use when
 [PM-XXXXX] <type>: <short imperative summary>
 ```
 
+**Type keywords** (triggers automatic `t:` label via CI):
+
+| Type | Label | Use for |
+|------|-------|---------|
+| `feat` | `t:feature` | New features or functionality |
+| `fix` | `t:bug` | Bug fixes |
+| `refactor` | `t:tech-debt` | Code restructuring without behavior change |
+| `chore` | `t:tech-debt` | Maintenance, cleanup, minor tweaks |
+| `test` | `t:tech-debt` | Adding or updating tests |
+| `perf` | `t:tech-debt` | Performance improvements |
+| `docs` | `t:docs` | Documentation changes |
+| `ci` / `build` | `t:ci` | CI/CD and build system changes |
+| `deps` | `t:deps` | Dependency updates |
+| `llm` | `t:llm` | LLM/Claude configuration changes |
+| `breaking` | `t:breaking-change` | Breaking changes requiring migration |
+| `misc` | `t:misc` | Changes that do not fit other categories |
+
 **Examples:**
 - `[PM-12345] feat: Add autofill support for passkeys`
 - `[PM-12345] fix: Resolve crash during vault sync`
 - `[PM-12345] refactor: Simplify authentication flow`
 
-**Rules:**
-- Include Jira ticket prefix
-- Keep under 70 characters total
-- Use imperative mood in the summary
-
-**Type keywords** (triggers automatic `t:` label via CI):
-
-**Use the `labeling-changes` skill** (invoke via the Skill tool) for the full type keyword table and selection guidance.
-
 ---
 
-## PR Body Template
+## PR Body
 
-**IMPORTANT:** Always follow the repo's PR template at `.github/PULL_REQUEST_TEMPLATE.md`. If no template exists, use this structure:
+**Always follow the repo's PR template at `.github/PULL_REQUEST_TEMPLATE.md`.** Read it and fill in each section. If no template exists, use this fallback:
 
 ```markdown
 ## Type of change
@@ -51,27 +59,16 @@ Delete the Screenshots section entirely if there are no UI changes.
 
 ---
 
-## Pre-PR Checklist
-
-1. **All tests pass** — consult CLAUDE.md or the repo's build/test skill for the correct test commands
-2. **Lint clean** — consult CLAUDE.md for the repo's lint command
-3. **Self-review done** — use the `perform-preflight` skill
-4. **No unintended changes**: Check `git diff origin/main...HEAD` for unexpected files
-5. **Branch up to date**: Rebase on `main` if needed
-
----
-
 ## Creating the PR
 
-```bash
-# Ensure branch is pushed
-git push -u origin <branch-name>
+Before creating, run `perform-preflight` if not already done.
 
-# Create PR as draft by default (body follows .github/PULL_REQUEST_TEMPLATE.md)
+```bash
+git push -u origin <branch-name>
 gh pr create --draft --title "[PM-XXXXX] feat: Short summary" --body "<fill in from PR template>"
 ```
 
-**Default to draft PRs.** Only create a non-draft (ready for review) PR if the user explicitly requests it.
+**Default to draft PRs.** Only create a non-draft PR if the user explicitly requests it.
 
 ---
 
@@ -87,10 +84,3 @@ If the user selects a label, include it via the `--label` flag:
 ```bash
 gh pr create --draft --label "ai-review-vnext" --title "..." --body "..."
 ```
-
----
-
-## Base Branch
-
-- Default target: `main`
-- Check with team if targeting a feature branch instead

--- a/plugins/bitwarden-delivery-tools/skills/labeling-changes/SKILL.md
+++ b/plugins/bitwarden-delivery-tools/skills/labeling-changes/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: labeling-changes
+description: Conventional commit type keywords for PR titles and commit messages. Use when determining the change type for commits or PRs. Triggered by "what type", "label", "change type", "conventional commit", "t: label".
+---
+
+# Labeling Changes
+
+PR titles and commit messages must include a conventional commit type keyword. This keyword drives automatic `t:` label assignment via CI (`.github/scripts/label-pr.py` reads `.github/label-pr.json`).
+
+## Format
+
+The type keyword appears after the Jira ticket prefix:
+
+```
+[PM-XXXXX] <type>: <imperative summary>
+```
+
+## Type Keywords
+
+| Type | Label | Use for |
+|------|-------|---------|
+| `feat` | `t:feature` | New features or functionality |
+| `fix` | `t:bug` | Bug fixes |
+| `refactor` | `t:tech-debt` | Code restructuring without behavior change |
+| `chore` | `t:tech-debt` | Maintenance, cleanup, minor tweaks |
+| `test` | `t:tech-debt` | Adding or updating tests |
+| `perf` | `t:tech-debt` | Performance improvements |
+| `docs` | `t:docs` | Documentation changes |
+| `ci` / `build` | `t:ci` | CI/CD and build system changes |
+| `deps` | `t:deps` | Dependency updates |
+| `llm` | `t:llm` | LLM/Claude configuration changes |
+| `breaking` | `t:breaking-change` | Breaking changes requiring migration |
+| `misc` | `t:misc` | Changes that do not fit other categories |
+
+## Selecting a Type
+
+Infer the type from the task description and changes made. **If the type cannot be confidently determined, ask the user.**
+
+The CI labeling script matches `<type>:` or `<type>(` in the lowercased PR title, so the keyword must be followed by a colon or parenthesis. CI also accepts additional aliases (e.g., `revert`, `bugfix`, `cleanup`). See `.github/label-pr.json` for the full mapping.

--- a/plugins/bitwarden-delivery-tools/skills/labeling-changes/SKILL.md
+++ b/plugins/bitwarden-delivery-tools/skills/labeling-changes/SKILL.md
@@ -37,3 +37,13 @@ The type keyword appears after the Jira ticket prefix:
 Infer the type from the task description and changes made. **If the type cannot be confidently determined, ask the user.**
 
 The CI labeling script matches `<type>:` or `<type>(` in the lowercased PR title, so the keyword must be followed by a colon or parenthesis. CI also accepts additional aliases (e.g., `revert`, `bugfix`, `cleanup`). See `.github/label-pr.json` for the full mapping.
+
+### Examples
+
+Ambiguous cases where type selection is non-obvious:
+
+- Refactor that incidentally fixes a bug → use the **primary intent**: `fix:` if the bug was the goal, `refactor:` if the restructuring was the goal
+- Adding tests for existing untested code → `test:` (not `chore:`)
+- Updating a dependency to fix a vulnerability → `deps:` (not `fix:`)
+- Changing Claude/LLM configuration files → `llm:` (not `chore:`)
+- Removing dead code → `refactor:` (not `chore:` — it changes the codebase structure)

--- a/plugins/bitwarden-delivery-tools/skills/perform-preflight/SKILL.md
+++ b/plugins/bitwarden-delivery-tools/skills/perform-preflight/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: perform-preflight
+description: Quality gate checklist to run before committing or creating a PR. Use when finishing implementation, checking work quality, or preparing to commit. Triggered by "preflight", "self review", "ready to commit", "check my work", "quality gate".
+---
+
+# Preflight Checklist
+
+Run this checklist before committing or creating a PR. Consult the repo's CLAUDE.md for platform-specific commands and requirements.
+
+## Tests
+
+- [ ] Run tests for affected modules — consult CLAUDE.md or the repo's build/test skill for the correct commands
+- [ ] New code has test coverage
+- [ ] No existing tests broken by changes
+
+## Code Quality
+
+- [ ] Lint passes — run the repo's linter (consult CLAUDE.md for the command)
+- [ ] Format passes — run the repo's formatter (consult CLAUDE.md for the command)
+- [ ] No TODO comments without Jira ticket references (if enforced by the repo)
+- [ ] Public APIs have documentation (KDoc, DocC, XML docs, etc. per repo convention)
+
+## Security
+
+- [ ] No plaintext secrets, API keys, or credentials in code or config
+- [ ] Sensitive data stored using platform-appropriate secure storage (consult CLAUDE.md Security Rules)
+- [ ] User input is validated before processing
+- [ ] No sensitive data in log statements
+- [ ] Zero-knowledge architecture preserved — no unencrypted vault data logged, persisted, or transmitted
+
+## Architecture
+
+- [ ] Changes follow established patterns documented in CLAUDE.md and architecture docs
+- [ ] No new patterns introduced when existing ones apply
+- [ ] DI/injection patterns followed per repo convention
+- [ ] Error handling follows repo convention (Result types, sealed classes, etc.)
+
+## Files
+
+- [ ] No build artifacts or generated files staged
+- [ ] No IDE-specific files staged (`.idea/`, `.xcuserdata/`, etc.)
+- [ ] No credential files or signing keys staged
+- [ ] String resources added to the correct location (if applicable)

--- a/plugins/bitwarden-delivery-tools/skills/perform-preflight/SKILL.md
+++ b/plugins/bitwarden-delivery-tools/skills/perform-preflight/SKILL.md
@@ -5,39 +5,32 @@ description: Quality gate checklist to run before committing or creating a PR. U
 
 # Preflight Checklist
 
-Run this checklist before committing or creating a PR. Consult the repo's CLAUDE.md for platform-specific commands and requirements.
+Run this checklist before committing or creating a PR. Consult the repo's CLAUDE.md for platform-specific commands (test runner, linter, formatter).
 
 ## Tests
 
-- [ ] Run tests for affected modules — consult CLAUDE.md or the repo's build/test skill for the correct commands
+- [ ] Run tests for affected modules (consult CLAUDE.md for commands)
 - [ ] New code has test coverage
-- [ ] No existing tests broken by changes
+- [ ] No existing tests broken
 
 ## Code Quality
 
-- [ ] Lint passes — run the repo's linter (consult CLAUDE.md for the command)
-- [ ] Format passes — run the repo's formatter (consult CLAUDE.md for the command)
-- [ ] No TODO comments without Jira ticket references (if enforced by the repo)
-- [ ] Public APIs have documentation (KDoc, DocC, XML docs, etc. per repo convention)
+- [ ] Lint and format pass (consult CLAUDE.md for commands)
+- [ ] No TODO comments without Jira ticket references
+- [ ] Public APIs documented per repo convention (KDoc, DocC, XML docs, etc.)
 
-## Security
+## Bitwarden Security
 
-- [ ] No plaintext secrets, API keys, or credentials in code or config
-- [ ] Sensitive data stored using platform-appropriate secure storage (consult CLAUDE.md Security Rules)
-- [ ] User input is validated before processing
-- [ ] No sensitive data in log statements
 - [ ] Zero-knowledge architecture preserved — no unencrypted vault data logged, persisted, or transmitted
+- [ ] Sensitive data uses platform-appropriate secure storage (consult CLAUDE.md Security Rules)
+- [ ] No sensitive data in log statements
 
 ## Architecture
 
-- [ ] Changes follow established patterns documented in CLAUDE.md and architecture docs
-- [ ] No new patterns introduced when existing ones apply
-- [ ] DI/injection patterns followed per repo convention
-- [ ] Error handling follows repo convention (Result types, sealed classes, etc.)
-
-## Files
-
-- [ ] No build artifacts or generated files staged
-- [ ] No IDE-specific files staged (`.idea/`, `.xcuserdata/`, etc.)
-- [ ] No credential files or signing keys staged
+- [ ] Changes follow patterns in CLAUDE.md and architecture docs
+- [ ] DI/injection and error handling follow repo convention
 - [ ] String resources added to the correct location (if applicable)
+
+## On Failure
+
+If any check fails, fix the issue before proceeding. For test failures, diagnose the root cause rather than skipping. For lint/format failures, run the repo's auto-fix command if available. If a check cannot be resolved, flag it to the user with the specific failure output.

--- a/plugins/bitwarden-software-engineer/.claude-plugin/plugin.json
+++ b/plugins/bitwarden-software-engineer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bitwarden-software-engineer",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Comprehensive full-stack software engineering assistant proficient in modern software development at Bitwarden.",
   "author": {
     "name": "Bitwarden",
@@ -8,6 +8,13 @@
   },
   "homepage": "https://github.com/bitwarden/ai-plugins/tree/main/plugins/bitwarden-software-engineer",
   "repository": "https://github.com/bitwarden/ai-plugins",
-  "keywords": ["typescript", "csharp", "sql", "fullstack"],
-  "agents": ["./agents/bitwarden-software-engineer.md"]
+  "keywords": [
+    "typescript",
+    "csharp",
+    "sql",
+    "fullstack"
+  ],
+  "agents": [
+    "./agents/bitwarden-software-engineer.md"
+  ]
 }

--- a/plugins/bitwarden-software-engineer/CHANGELOG.md
+++ b/plugins/bitwarden-software-engineer/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to the `bitwarden-software-engineer` plugin will be document
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-04-08
+
+### Changed
+
+- Agent now autonomously drives full implementation lifecycle with self-review protocol (implement, test, build, preflight, commit)
+- Added dynamic context discovery via CLAUDE.md Skills & Commands table — agent discovers and invokes repo-local skills at runtime
+- Added `Agent` and `Skill` (bare) to tools for dynamic discovery and sub-agent deployment
+- Removed preloaded skill frontmatter — all skills are now discovered dynamically from CLAUDE.md and installed plugins
+- Added decision-making framework and critical rules from per-repo implementer agents
+- Replaces per-repo implementer agents (`android-implementer`, `ios-implementer`)
+
 ## [0.3.0] - 2026-02-23
 
 ### Added

--- a/plugins/bitwarden-software-engineer/agents/bitwarden-software-engineer.md
+++ b/plugins/bitwarden-software-engineer/agents/bitwarden-software-engineer.md
@@ -41,7 +41,7 @@ Whether driven by a command or manually, the lifecycle follows these phases:
 
 ## Self-Review Protocol
 
-At each phase transition, evaluate your own output rather than waiting for human approval:
+At each phase transition, evaluate your own output:
 
 ```
 --- Phase Review: [Phase Name] ---
@@ -52,21 +52,6 @@ Action: [Proceeding to next phase / Iterating on: X]
 ```
 
 If status is NEEDS REFINEMENT, iterate up to 3 times before proceeding with the best available output and noting remaining concerns.
-
-**Review criteria by phase:**
-- **Implementation**: Follows skill guidance and CLAUDE.md anti-patterns list?
-- **Testing**: Covers happy path, error cases, and edge cases?
-- **Build & Verify**: All tests pass? No compilation errors or warnings?
-- **Preflight**: Would this pass code review by a senior engineer?
-- **Commit**: Message clear, properly formatted, and accurate?
-
-## Decision-Making Framework
-
-- **When uncertain about a pattern**: Search the codebase for existing examples. Follow what exists rather than inventing.
-- **When finding multiple valid approaches**: Choose the one most consistent with nearby code in the same module.
-- **When discovering scope creep**: Note it as a follow-up item and stay focused on the original task.
-- **When tests fail**: Diagnose the root cause, fix it, and re-run. Don't skip failing tests.
-- **When a phase produces subpar output**: Iterate. Don't advance with known deficiencies unless you've exhausted reasonable refinement attempts.
 
 ## Skill Routing
 
@@ -91,17 +76,3 @@ When the `bitwarden-security-engineer` plugin is installed, use security skills 
 - **Working with secrets or configuration** → `Skill(detecting-secrets)`
 
 These skills are optional — if unavailable, proceed with your standard workflow.
-
-## Communication Style
-
-- Be concise and direct in phase transition summaries
-- Provide detailed technical reasoning only when making non-obvious decisions
-- Flag any genuine blockers that require human input clearly and specifically
-- At completion, provide a summary of what was implemented, what was tested, and any follow-up items
-
-## Critical Rules
-
-1. **Minimize user interruptions**: Only escalate for genuine ambiguities that codebase context cannot resolve.
-2. **Never skip testing**: Every implementation phase must have corresponding tests.
-3. **Never invent new patterns**: Use established codebase patterns. Search for examples first.
-4. **Never leave the codebase in a broken state**: If you can't complete a phase cleanly, revert and explain why.

--- a/plugins/bitwarden-software-engineer/agents/bitwarden-software-engineer.md
+++ b/plugins/bitwarden-software-engineer/agents/bitwarden-software-engineer.md
@@ -1,63 +1,107 @@
 ---
 name: bitwarden-software-engineer
-description: Full-stack software engineer specializing in C#, JavaScript, TypeScript, and SQL. Coordinates complex development tasks across languages. Use for feature implementation, and cross-language refactoring.
+description: "Autonomously implements features, fixes bugs, and completes development tasks across any Bitwarden repository. Drives the full implementation lifecycle (implement, test, build, preflight, commit) with self-review at each phase. Use for end-to-end implementation, cross-language refactoring, or when planning output is ready for implementation."
+version: 0.4.0
 model: opus
-tools: Read, Write, Edit, Bash, Glob, Grep
-skills:
-  - writing-client-code
-  - writing-server-code
-  - writing-database-queries
+tools: Bash, Read, Edit, Write, Glob, Grep, Agent, Skill
 color: blue
 ---
 
-You are a senior full-stack software engineer with expertise across C#, JavaScript, TypeScript, and SQL. You're an engineer working with the team, not just executing commands. Focus intently on code quality **over** code quantity. You avoid over-engineering because you focus on what's needed, not what might be needed.
+You are a senior software engineer working across Bitwarden's full stack. You autonomously drive implementation from start to finish, acting as both the implementer and the quality reviewer at each phase.
 
-## Purpose
+## Step 1: Context Discovery
 
-Coordinate complex software development tasks that span multiple languages, architectural concerns, or require full-stack reasoning.
+Before implementing, orient yourself in the target repository:
 
-## Working Approach
+1. **Read the repo's CLAUDE.md** to learn:
+   - Architecture constraints and key principles
+   - Security rules (especially zero-knowledge requirements)
+   - Code organization and module structure
+   - Available skills and commands from the **Skills & Commands** table
 
-1. **Understand context:** Before creating or modifying code, read the relevant existing files to understand current patterns. Don't assume — verify.
-2. **Clarify, don't invent.** If requirements are ambiguous or incomplete, ask the human rather than making assumptions. State what you're uncertain about.
-3. **Stay in scope.** Implement what was asked. Don't add features, abstractions, or "nice-to-haves" that weren't requested. If you see an improvement opportunity, mention it — don't just build it.
-4. **Build incrementally, validate continuously.** Start with core functionality, run tests, check for regressions, and confirm the implementation meets requirements before declaring done.
+2. **Identify implementation skills** from the Skills & Commands table — look for skills matching triggers like "implement", "write code", "add screen", "create feature". **Use the `Skill` tool to invoke them by name.** Do NOT read the SKILL.md file directly.
+
+3. **Identify the testing skill** — look for triggers like "write tests", "add test coverage", "unit test". Invoke it when writing tests.
+
+4. **Identify the build/verify skill** — look for triggers like "build", "run tests", "lint", "format". Invoke it for build and verification commands.
+
+5. **Identify the implementation command** — look for a command matching "full workflow", "implement", "work on" (e.g., `/work-on-android`, `/work-on-ios`). If one exists, **use the `Skill` tool to invoke it** — it defines the phases and structures the entire implementation lifecycle. Let the command drive the phase sequence rather than manually orchestrating skills.
+
+6. **If no implementation command exists**: Drive the lifecycle manually using the skills you discovered.
+
+## Step 2: Implementation Lifecycle
+
+Whether driven by a command or manually, the lifecycle follows these phases:
+
+1. **Implement** — Write code following repo patterns. Search the codebase for existing examples before inventing anything.
+2. **Test** — Write tests covering happy path, error cases, and edge cases.
+3. **Build & Verify** — Run the repo's build, test, and lint tools. Fix any failures.
+4. **Preflight** — Use the `bitwarden-delivery-tools:perform-preflight` skill for quality gate checks.
+5. **Commit** — Use the `bitwarden-delivery-tools:committing-changes` skill for commit format and staging.
+
+## Self-Review Protocol
+
+At each phase transition, evaluate your own output rather than waiting for human approval:
+
+```
+--- Phase Review: [Phase Name] ---
+Status: APPROVED / NEEDS REFINEMENT
+Findings: [brief assessment]
+Action: [Proceeding to next phase / Iterating on: X]
+---
+```
+
+If status is NEEDS REFINEMENT, iterate up to 3 times before proceeding with the best available output and noting remaining concerns.
+
+**Review criteria by phase:**
+- **Implementation**: Follows skill guidance and CLAUDE.md anti-patterns list?
+- **Testing**: Covers happy path, error cases, and edge cases?
+- **Build & Verify**: All tests pass? No compilation errors or warnings?
+- **Preflight**: Would this pass code review by a senior engineer?
+- **Commit**: Message clear, properly formatted, and accurate?
+
+## Decision-Making Framework
+
+- **When uncertain about a pattern**: Search the codebase for existing examples. Follow what exists rather than inventing.
+- **When finding multiple valid approaches**: Choose the one most consistent with nearby code in the same module.
+- **When discovering scope creep**: Note it as a follow-up item and stay focused on the original task.
+- **When tests fail**: Diagnose the root cause, fix it, and re-run. Don't skip failing tests.
+- **When a phase produces subpar output**: Iterate. Don't advance with known deficiencies unless you've exhausted reasonable refinement attempts.
 
 ## Skill Routing
 
-The architectural skills (`writing-client-code`, `writing-server-code`, `writing-database-queries`) are preloaded. For implementation tasks, activate the appropriate skill:
+All skills are discovered dynamically from the repo's CLAUDE.md Skills & Commands table and from installed marketplace plugins. For server-specific work, the following plugin skills are available:
 
-- **Dapper/stored procedure work** (creating SPs, MSSQL migrations, Dapper repository methods) → activate `implementing-dapper-queries`
-- **EF Core work** (EF repositories, EF migrations, PostgreSQL/MySQL/SQLite) → activate `implementing-ef-core`
-- **Both ORMs** (new repository interface that needs both implementations) → activate both implementation skills
+- **Dapper/stored procedure work** → `Skill(implementing-dapper-queries)`
+- **EF Core work** → `Skill(implementing-ef-core)`
+- **Both ORMs** → invoke both implementation skills
+- **Client code** → `Skill(writing-client-code)`
+- **Server code** → `Skill(writing-server-code)`
+- **Database queries** → `Skill(writing-database-queries)`
 
-## Verification
-
-After making changes, always verify your work before declaring done. Use the appropriate commands for the codebase you modified:
-
-### Server repo (C#/.NET)
-
-- **Build:** `dotnet build` from the solution root
-- **Unit tests:** `dotnet test` targeting the relevant test project (e.g., `test/Core.Test`)
-- **Integration tests:** Run tests with `[DatabaseData]` attribute when database changes are involved
-
-### Client repo (Angular/TypeScript)
-
-- **Build:** `npm run build` in the relevant app directory (`apps/web`, `apps/browser`, etc.)
-- **Lint:** `npm run lint` to catch style violations
-- **Unit tests:** `npm run test` in the relevant library or app directory
-
-### Database changes
-
-- Verify your changes against the conventions in the active database skill (`implementing-dapper-queries`, `implementing-ef-core`, or `writing-database-queries`)
+For repos with local implementation skills (Android, iOS, SDK, etc.), discover and invoke them via the Skills & Commands table in CLAUDE.md.
 
 ## Security-Aware Development
 
-When the `bitwarden-security-engineer` plugin is installed, additional security skills are available. Use them proactively:
+When the `bitwarden-security-engineer` plugin is installed, use security skills proactively:
 
-- **Before implementing auth/crypto/access-control features** → activate `Skill(reviewing-security-architecture)` to verify your design against approved patterns (token handling, RBAC, encryption at rest/transit, trust boundaries)
-- **When handling user input that reaches SQL, HTML, file system, or URLs** → activate `Skill(analyzing-code-security)` to check for injection, XSS, SSRF, and path traversal against Bitwarden's vulnerability pattern library
-- **When adding or updating dependencies** → activate `Skill(reviewing-dependencies)` to assess supply chain risk before introducing new packages
-- **When working with secrets or configuration** → activate `Skill(detecting-secrets)` to verify no credentials are hardcoded
+- **Auth/crypto/access-control features** → `Skill(reviewing-security-architecture)`
+- **User input reaching SQL, HTML, file system, URLs** → `Skill(analyzing-code-security)`
+- **Adding or updating dependencies** → `Skill(reviewing-dependencies)`
+- **Working with secrets or configuration** → `Skill(detecting-secrets)`
 
-These skills are optional — if unavailable (plugin not installed), proceed with your standard workflow.
+These skills are optional — if unavailable, proceed with your standard workflow.
+
+## Communication Style
+
+- Be concise and direct in phase transition summaries
+- Provide detailed technical reasoning only when making non-obvious decisions
+- Flag any genuine blockers that require human input clearly and specifically
+- At completion, provide a summary of what was implemented, what was tested, and any follow-up items
+
+## Critical Rules
+
+1. **Minimize user interruptions**: Only escalate for genuine ambiguities that codebase context cannot resolve.
+2. **Never skip testing**: Every implementation phase must have corresponding tests.
+3. **Never invent new patterns**: Use established codebase patterns. Search for examples first.
+4. **Never leave the codebase in a broken state**: If you can't complete a phase cleanly, revert and explain why.

--- a/plugins/bitwarden-workflows/.claude-plugin/plugin.json
+++ b/plugins/bitwarden-workflows/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bitwarden-workflows",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Multi-agent orchestration workflows for Bitwarden development. Composes marketplace agents into end-to-end pipelines via Teams and task dependencies.",
   "author": {
     "name": "Bitwarden",

--- a/plugins/bitwarden-workflows/.claude-plugin/plugin.json
+++ b/plugins/bitwarden-workflows/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "bitwarden-workflows",
+  "version": "0.1.0",
+  "description": "Multi-agent orchestration workflows for Bitwarden development. Composes marketplace agents into end-to-end pipelines via Teams and task dependencies.",
+  "author": {
+    "name": "Bitwarden",
+    "url": "https://github.com/bitwarden"
+  },
+  "homepage": "https://github.com/bitwarden/ai-marketplace/tree/main/plugins/bitwarden-workflows",
+  "repository": "https://github.com/bitwarden/ai-marketplace",
+  "keywords": ["workflow", "orchestration", "pipeline", "plan-implement-review", "teams"]
+}

--- a/plugins/bitwarden-workflows/CHANGELOG.md
+++ b/plugins/bitwarden-workflows/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the `bitwarden-workflows` plugin will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.0] - 2026-04-13
+## [1.0.0] - 2026-04-13
 
 ### Added
 

--- a/plugins/bitwarden-workflows/CHANGELOG.md
+++ b/plugins/bitwarden-workflows/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to the `bitwarden-workflows` plugin will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2026-04-13
+
+### Added
+
+- `plan-implement-review` skill — end-to-end pipeline orchestrating requirements analysis, per-repo architecture planning, implementation with self-review, and multi-agent code review via Teams and task dependencies
+- Reference implementation for composing marketplace agents (product-analyst, architect, software-engineer, security-engineer, code-reviewer) into complex multi-step workflows

--- a/plugins/bitwarden-workflows/README.md
+++ b/plugins/bitwarden-workflows/README.md
@@ -1,0 +1,41 @@
+# Bitwarden Workflows
+
+Multi-agent orchestration workflows for Bitwarden development. Composes marketplace agents into end-to-end pipelines via Teams and task dependencies.
+
+## Overview
+
+This plugin provides composed workflows that coordinate multiple marketplace agents into structured, multi-step pipelines. Each workflow uses Teams for teammate management, task dependencies for execution ordering, and dynamic per-repo agent dispatch for cross-repo features.
+
+## Skills
+
+| Skill | Triggers | Purpose |
+|-------|---------|---------|
+| `plan-implement-review` | "plan and implement", "PIR", "end-to-end pipeline" | Full development pipeline: requirements → architecture → implementation → review |
+
+## plan-implement-review
+
+End-to-end development pipeline that orchestrates 6 agent types through a structured lifecycle:
+
+1. **Plan** (once) — Product analyst produces requirements, per-repo architects produce implementation plans in parallel, then a work breakdown and QA handoff are consolidated
+2. **Implement + Review** (per phase) — Per-repo software engineers implement each phase, then a 4-reviewer gauntlet (requirements, architecture, security, code quality) reviews the changes with up to 3 fix rounds before escalation
+3. **Shutdown** — Teammates are shut down, artifacts summarized, next steps suggested
+
+Supports `--confirm` flag for gated mode (user approval between phases) or runs autonomously by default. Handles multi-repo Epics by dynamically creating per-repo architects and implementers based on what the requirements spec identifies as in scope.
+
+### Prerequisites
+
+| Plugin | Role in pipeline |
+|--------|-----------------|
+| `bitwarden-product-analyst` | Requirements analysis, QA handoff, requirements review |
+| `bitwarden-architect` | Architecture planning, architecture review |
+| `bitwarden-software-engineer` | Implementation with self-review |
+| `bitwarden-security-engineer` | Security review |
+| `bitwarden-code-review` | Code quality review |
+| `bitwarden-delivery-tools` | Committing, PRs, preflight, labeling |
+| `bitwarden-atlassian-tools` | Optional — Jira/Confluence fetching |
+
+Missing plugins are skipped gracefully rather than blocking the pipeline.
+
+## Installation
+
+Install via the Bitwarden AI Marketplace.

--- a/plugins/bitwarden-workflows/skills/plan-implement-review/SKILL.md
+++ b/plugins/bitwarden-workflows/skills/plan-implement-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
-description: End-to-end pipeline orchestrating requirements analysis, architecture planning, implementation, and multi-agent code review via agent team
-argument-hint: <task description, Jira ticket, or Confluence URL> [--confirm]
+name: plan-implement-review
+description: End-to-end pipeline orchestrating requirements analysis, architecture planning, implementation, and multi-agent code review via agent team. Use when starting a feature from a Jira ticket, planning multi-repo work, or running a full plan-implement-review cycle. Triggered by "plan and implement", "plan-implement-review", "end-to-end pipeline", "PIR".
 ---
 
 # Plan-Implement-Review Pipeline
@@ -14,12 +14,12 @@ You are the **team lead** for an end-to-end development pipeline. Use **Claude A
 Parse `$ARGUMENTS`: strip `--confirm` flag (enables **gated mode** — present output and get user approval between phases; default is **autonomous mode**). Derive a slug from the task description (lowercase, hyphens, max 40 chars).
 
 **Output paths** (using slug):
-- `.claude/outputs/plans/{slug}-REQUIREMENTS.md`
-- `.claude/outputs/plans/{slug}-IMPL-{REPO}.md` (one per in-scope repo)
-- `.claude/outputs/plans/{slug}-WORK-BREAKDOWN.md`
-- `.claude/outputs/plans/{slug}-QA-HANDOFF.md`
-- `.claude/outputs/reviews/{slug}-REVIEW-{REVIEWER}.md` (one per reviewer per phase)
-- `.claude/outputs/reviews/{slug}-REVIEW-SUMMARY.md`
+- `${CLAUDE_PLUGIN_DATA}/plans/{slug}-REQUIREMENTS.md`
+- `${CLAUDE_PLUGIN_DATA}/plans/{slug}-IMPL-{REPO}.md` (one per in-scope repo)
+- `${CLAUDE_PLUGIN_DATA}/plans/{slug}-WORK-BREAKDOWN.md`
+- `${CLAUDE_PLUGIN_DATA}/plans/{slug}-QA-HANDOFF.md`
+- `${CLAUDE_PLUGIN_DATA}/reviews/{slug}-REVIEW-{REVIEWER}.md` (one per reviewer per phase)
+- `${CLAUDE_PLUGIN_DATA}/reviews/{slug}-REVIEW-SUMMARY.md`
 
 ## Pipeline Structure
 
@@ -52,7 +52,7 @@ If a plugin is not installed, offer to **skip that teammate** rather than blocki
 
 ## Step 1: Create Team
 
-Team name: `pir-{slug}`. Create `.claude/outputs/plans/` and `.claude/outputs/reviews/` directories.
+Team name: `pir-{slug}`. Create `${CLAUDE_PLUGIN_DATA}/plans/` and `${CLAUDE_PLUGIN_DATA}/reviews/` directories.
 
 ## Step 2: Plan Phase
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-35116: Cross-repo PIR workflow](https://bitwarden.atlassian.net/browse/PM-35116)
[PM-35361: Delivery tools](https://bitwarden.atlassian.net/browse/PM-35361)
[PM-35362: Workflows plugin](https://bitwarden.atlassian.net/browse/PM-35362)

## 📔 Objective

> **WIP** — Active development. Publishing early to share direction and
> prevent duplicate work across the team.

Introduces an architect agent and supporting plugins that discover platform
context dynamically at runtime, plus a workflows plugin that demonstrates how
to compose marketplace agents into multi-agent pipelines.

### New plugins

**`bitwarden-architect`** — Software architect agent with three bundled skills
covering the planning lifecycle: `architecting-solutions` (think: security
posture, blast radius, trade-offs), `creating-implementation-plan` (produce the
plan artifact), and `creating-work-breakdown` (decompose phases into
ticket-ready tasks). Agent workflow defaults to stopping after the "think"
step unless the human explicitly asks for a plan or tickets. Discovers
planning-related skills under `<repo>/.claude/skills/` and defers to them when
present; otherwise uses the plugin's built-in templates.

**`bitwarden-delivery-tools`** — Generic delivery skills (committing-changes,
creating-pull-request, labeling-changes, perform-preflight) that derive
platform-specific details from each repo's CLAUDE.md.

**`bitwarden-workflows`** — Multi-agent orchestration workflows composed from
marketplace agents via Teams and task dependencies. Ships with
`plan-implement-review` as the first workflow: an end-to-end pipeline
(requirements → per-repo architecture → implementation → 4-reviewer gauntlet)
that dynamically creates per-repo architects and implementers based on what the
requirements spec identifies as in scope.

### Updated plugins

**`bitwarden-software-engineer`** — Adjusted to be more generic: adds context
discovery via CLAUDE.md, autonomous implementation lifecycle with self-review
protocol, and decision-making framework. All skills discovered dynamically at
runtime.

### Design principle

Agents own process. Repos own platform specifics. The `plan-implement-review`
workflow in bitwarden-workflows is both a functional pipeline and a reference
for how to compose agents into complex, multi-step, multi-repo workflows using
Teams and task dependencies.

### Follow-up: relocate repo-specific skills

The `bitwarden-software-engineer` plugin currently contains 5 skills that are
repo-specific implementation conventions rather than process:
`writing-server-code`, `writing-client-code`, `writing-database-queries`,
`implementing-dapper-queries`, `implementing-ef-core`. Per the design principle,
these belong in their respective repos' `.claude/skills/` directories (server,
clients) — not the marketplace. Relocating them makes the software-engineer
a pure process agent with zero repo-specific content, consistent with how the
architect and delivery-tools plugins already work. This will be a separate PR
touching the server and clients repos.

---

## Testing

### Prerequisites

Install all plugins from this branch. Verify with `/reload-plugins`:
- `bitwarden-architect`, `bitwarden-delivery-tools`, `bitwarden-workflows` (new)
- `bitwarden-software-engineer` (updated)
- `bitwarden-product-analyst`, `bitwarden-security-engineer`, `bitwarden-code-review`, `bitwarden-atlassian-tools` (existing, required by the pipeline)

Ensure `bitwarden-atlassian-tools` is configured and functional (Jira/Confluence access required for ticket-based workflows).

<details>
<summary><strong>Test 1: Architect workflow (Think → Plan → Break down)</strong></summary>

The architect agent bundles three skills auto-loaded into context: `architecting-solutions`, `creating-implementation-plan`, `creating-work-breakdown`. Default behavior stops after the "think" step; plan and work-breakdown artifacts are only produced on explicit request.

**Think-only (default):**
1. Open a **new session** in a target repo directory
2. Dispatch `bitwarden-architect:architect` with a brief feature request (no mention of planning or tickets)
3. Observe: agent reads CLAUDE.md, explores the codebase for pattern anchors, and returns architectural reasoning (security posture, blast radius, trade-offs, red flags). It should **not** produce a plan or work-breakdown document.

**Think + Plan:**
1. Repeat with a request that explicitly asks for an implementation plan
2. Observe: agent applies `architecting-solutions`, then produces `${CLAUDE_PLUGIN_DATA}/plans/{slug}-IMPLEMENTATION-PLAN.md` with the template sections (Current State / Blast Radius / Design / Phases / Risks & Open Questions)

**Think + Plan + Break down:**
1. Repeat with a request that explicitly asks for the plan to be broken into tickets
2. Observe: agent produces both `{slug}-IMPLEMENTATION-PLAN.md` and `{slug}-WORK-BREAKDOWN.md`, paired by slug

**Per-repo planning skill precedence:**
1. Run in a repo that has its own planning-related skill under `.claude/skills/` (e.g., android's `planning-android-implementation`)
2. Observe: agent defers the plan artifact's shape to the repo skill rather than using the plugin's default template

**Fallback test:**
1. Run in a repo with CLAUDE.md but **no** repo-local planning skill (e.g., server, sdk-internal)
2. Observe: agent uses the default template from `creating-implementation-plan`
</details>

<details>
<summary><strong>Test 2: Software-engineer context discovery</strong></summary>

1. Open a **new session** in a repo with implementation skills
2. Dispatch `bitwarden-software-engineer:bitwarden-software-engineer` with a small implementation task
3. Observe: does it read CLAUDE.md, find the Skills & Commands table, and invoke the implementation skill via `Skill` tool?
</details>

<details>
<summary><strong>Test 3: Delivery skills</strong></summary>

1. Make a small change in any repo
2. Invoke `bitwarden-delivery-tools:committing-changes` — verify it follows the commit format and invokes `labeling-changes` for type selection
3. Invoke `bitwarden-delivery-tools:creating-pull-request` — verify it prompts for AI review label via `AskUserQuestion` and creates a draft PR
</details>

<details>
<summary><strong>Test 4: End-to-end pipeline</strong></summary>

#### Setup

Create an isolated experiment workspace with worktrees on the companion PR branches (android, ios) and `origin/main` for other repos. This prevents agents from discovering old local agents in the main checkouts.

```bash
mkdir -p ~/development/bitwarden/experiment

# Repos with companion PRs — branch from the PR branch
cd ~/development/bitwarden/android
git worktree add ~/development/bitwarden/experiment/android \
  -b llm/pm-XXXXX-experiment llm/generic-architect-updates

cd ~/development/bitwarden/ios
git worktree add ~/development/bitwarden/experiment/ios \
  -b llm/pm-XXXXX-experiment llm/generic-architect-updates

# Other repos — branch from origin/main
for repo in server clients sdk-internal; do
  cd ~/development/bitwarden/$repo
  git fetch origin main
  git worktree add ~/development/bitwarden/experiment/$repo \
    -b llm/pm-XXXXX-experiment origin/main
done
```

#### Execution

1. Open a **new session** (fresh context) with working directory `~/development/bitwarden/experiment/`
2. Run: `Skill(bitwarden-workflows:plan-implement-review) <Jira ticket or task description>`
3. **Do not intervene** unless the pipeline crashes. If gated-mode prompts appear, approve.

**Single-blind protocol**: The agents are the test subjects. They receive only the task — no mention of testing, no evaluation criteria, no expected outcomes. The evaluator reviews artifacts after the run.

#### Evaluation criteria

| Category | What to check |
|----------|--------------|
| Context discovery | Did agents read CLAUDE.md and invoke skills via `Skill` tool (not file reads)? |
| Multi-repo awareness | Did the pipeline identify multiple in-scope repos and create per-repo agents? |
| Plan quality | Do plans reference specific existing files, follow platform patterns, include concrete tasks? |
| Implementation quality | Does code follow the plan, include tests, pass builds? |
| Pipeline mechanics | Were teams/tasks created correctly, did reviewers wait for commits? |

#### Cleanup

Remove experiment worktrees after evaluation. Verify no commits were pushed to remotes.
</details>

[PM-35116]: https://bitwarden.atlassian.net/browse/PM-35116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
