### PR TITLE
Enhance review code workflow to trigger on PR publish

### DIFF
--- a/.github/workflows/review-code.yml
+++ b/.github/workflows/review-code.yml
@@ -2,7 +2,7 @@ name: Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions: {}
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-34598](https://bitwarden.atlassian.net/browse/PM-34598)

## 📔 Objective

We have noticed that the ai-review label is being applied by engineers right before a draft PR is published. 

Starting here with our ai-plugins repo to ensure all works as expected before spamming all other repos.

[PM-34598]: https://bitwarden.atlassian.net/browse/PM-34598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ