### PR TITLE
Update Atlassian plugin documentation to clarify Cloud ID location

### DIFF
--- a/plugins/bitwarden-atlassian-tools/README.md
+++ b/plugins/bitwarden-atlassian-tools/README.md
@@ -9,7 +9,7 @@ Read-only Atlassian access via a custom MCP server providing Jira issue retrieva
 Configure the following environment variables:
 
 ```bash
-# Required — Atlassian Cloud ID (find yours at https://your-domain.atlassian.net/_edge/tenant_info)
+# Required — Atlassian Cloud ID (find yours at https://bitwarden.atlassian.net/_edge/tenant_info)
 export ATLASSIAN_CLOUD_ID="your-cloud-id"
 export ATLASSIAN_EMAIL="your-email@company.com"
 export ATLASSIAN_JIRA_READ_ONLY_TOKEN="your-jira-scoped-token"


### PR DESCRIPTION
## 📔 Objective

Currently, the environment variable specified in the Readme for the Atlassian tools references `https://your-domain.atlassian.net`. This updates that to be more clearly `https://bitwarden.atlassian.net`, since that is the domain this plugin will be used for.
