### PR TITLE
Tech lead agent skill development

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -67,8 +67,8 @@
     {
       "name": "bitwarden-tech-lead",
       "source": "./plugins/bitwarden-tech-lead",
-      "version": "2.0.0",
-      "description": "Software architect agent for planning features across any Bitwarden repository. Discovers platform context dynamically via CLAUDE.md and repo-local planning skills."
+      "version": "2.1.0",
+      "description": "Tech lead agent for a Bitwarden product team. Architects solutions holistically with the architecture group, dispatches to delivery-lifecycle skills (initiative funnel, work transitions) when work crosses teams, and surfaces team patterns to the Technical Strategy Ideas backlog."
     },
     {
       "name": "bitwarden-delivery-tools",

--- a/.cspell.json
+++ b/.cspell.json
@@ -58,6 +58,7 @@
     "startswith",
     "stride",
     "structurizr",
+    "touchpoints",
     "triaging",
     "unresponded",
     "unsanitized",

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A curated collection of plugins for AI-assisted development at Bitwarden. Enable
 
 | Plugin                                                              | Version | Description                                                                                                         |
 | ------------------------------------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------- |
-| [bitwarden-tech-lead](plugins/bitwarden-tech-lead/)                 | 2.0.0   | Software architect for technical planning, architecture reviews, and implementation phasing                         |
+| [bitwarden-tech-lead](plugins/bitwarden-tech-lead/)                 | 2.1.0   | Tech lead for technical planning, architecture coherence, and surfacing patterns to Technical Strategy Ideas        |
 | [bitwarden-atlassian-tools](plugins/bitwarden-atlassian-tools/)     | 2.2.3   | Read-only Atlassian access via MCP server with deep Jira issue research skill                                       |
 | [bitwarden-code-review](plugins/bitwarden-code-review/)             | 1.10.0  | Autonomous code review agent following Bitwarden engineering standards with GitHub integration                      |
 | [bitwarden-delivery-tools](plugins/bitwarden-delivery-tools/)       | 1.1.0   | Delivery lifecycle skills: initiative funnel navigation, work transitions, commits, PRs, preflight checks, labeling |

--- a/plugins/bitwarden-tech-lead/.claude-plugin/plugin.json
+++ b/plugins/bitwarden-tech-lead/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "bitwarden-tech-lead",
-  "version": "2.0.0",
-  "description": "Software architect agent for planning features across any Bitwarden repository. Discovers platform context dynamically via CLAUDE.md and repo-local planning skills.",
+  "version": "2.1.0",
+  "description": "Tech lead agent for a Bitwarden product team. Architects solutions holistically with the architecture group, dispatches to delivery-lifecycle skills (initiative funnel, work transitions) when work crosses teams, and surfaces team patterns to the Technical Strategy Ideas backlog.",
   "author": {
     "name": "Bitwarden",
     "url": "https://github.com/bitwarden"
@@ -9,11 +9,11 @@
   "homepage": "https://github.com/bitwarden/ai-plugins/tree/main/plugins/bitwarden-tech-lead",
   "repository": "https://github.com/bitwarden/ai-plugins",
   "keywords": [
-    "architect",
-    "planning",
-    "implementation-plan",
-    "requirements",
-    "work-breakdown"
+    "tech-lead",
+    "architecture",
+    "technical-strategy",
+    "epic-breakdown",
+    "planning"
   ],
   "agents": "./agents/AGENT.md"
 }

--- a/plugins/bitwarden-tech-lead/CHANGELOG.md
+++ b/plugins/bitwarden-tech-lead/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to the `bitwarden-tech-lead` plugin will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - 2026-05-07
+
+### Added
+
+- `contributing-to-technical-strategy` skill. Full vertical guidance from Technical Strategy Ideas through BW Initiatives down to team-level epic and story breakdown: recognizing when a team-level pattern belongs upstream, framing a TSI well enough for Architecture to evaluate it, the ARCH idea ↔ BW Initiative linkage, and defining epic- and story-level work downward.
+- `architecting-solutions` gains two sections: _Working with the Architecture Group (Holistic Coherence)_ drawing on the Architecture / Engineering Operating Model, and _Working with the Initiative Shepherd_ drawing on the Software Initiative Funnel.
+
+### Changed
+
+- Reframed `AGENT.md` from "senior software architect" to a tech lead embedded in a product team who works alongside shepherds and the architecture group rather than replacing either. Added a three-rule decision tree for distinguishing "operate alongside the shepherd" from "propose taking on the shepherd role" based on scope rather than title.
+- AGENT.md now dispatches to `Skill(navigating-the-initiative-funnel)` and `Skill(running-work-transitions)` cross-plugin (skills live in `bitwarden-delivery-tools`). The agent stays funnel-aware while the funnel mechanics are agent-neutral and reusable.
+- Skill descriptions and content rewritten in third-person, process-focused voice (per team feedback). Persona framing lives in `AGENT.md`, not in the skills.
+- Plugin description and keywords updated to reflect the holistic-architecture and technical-strategy framing.
+- README updated to list the two skills retained in this plugin and the cross-plugin delivery-lifecycle skills.
+
+### Removed
+
+- `navigating-the-initiative-funnel` and `running-work-transitions` skills (moved to `bitwarden-delivery-tools` 1.1.0 in [#109](https://github.com/bitwarden/ai-plugins/pull/109) so multiple agents can compose them). The agent invokes them cross-plugin.
+
 ## [2.0.0] - 2026-04-24
 
 ### Changed

--- a/plugins/bitwarden-tech-lead/CHANGELOG.md
+++ b/plugins/bitwarden-tech-lead/CHANGELOG.md
@@ -9,20 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `contributing-to-technical-strategy` skill. Full vertical guidance from Technical Strategy Ideas through BW Initiatives down to team-level epic and story breakdown: recognizing when a team-level pattern belongs upstream, framing a TSI well enough for Architecture to evaluate it, the ARCH idea ↔ BW Initiative linkage, and defining epic- and story-level work downward.
-- `architecting-solutions` gains two sections: _Working with the Architecture Group (Holistic Coherence)_ drawing on the Architecture / Engineering Operating Model, and _Working with the Initiative Shepherd_ drawing on the Software Initiative Funnel.
+- `contributing-to-technical-strategy` skill — guides the path from Technical Strategy Ideas through BW Initiatives down to team-level epic and story breakdown.
+- `architecting-solutions` gains _Working with the Architecture Group (Holistic Coherence)_ and _Working with the Initiative Shepherd_ sections.
 
 ### Changed
 
-- Reframed `AGENT.md` from "senior software architect" to a tech lead embedded in a product team who works alongside shepherds and the architecture group rather than replacing either. Added a three-rule decision tree for distinguishing "operate alongside the shepherd" from "propose taking on the shepherd role" based on scope rather than title.
-- AGENT.md now dispatches to `Skill(navigating-the-initiative-funnel)` and `Skill(running-work-transitions)` cross-plugin (skills live in `bitwarden-delivery-tools`). The agent stays funnel-aware while the funnel mechanics are agent-neutral and reusable.
-- Skill descriptions and content rewritten in third-person, process-focused voice (per team feedback). Persona framing lives in `AGENT.md`, not in the skills.
+- Reframed `AGENT.md` from "senior software architect" to a tech lead embedded in a product team. Adds a scope-based decision tree for when to operate alongside a shepherd vs. take on the shepherd role.
+- Agent dispatches to `Skill(navigating-the-initiative-funnel)` and `Skill(running-work-transitions)` from `bitwarden-delivery-tools` (1.1.0+).
 - Plugin description and keywords updated to reflect the holistic-architecture and technical-strategy framing.
-- README updated to list the two skills retained in this plugin and the cross-plugin delivery-lifecycle skills.
-
-### Removed
-
-- `navigating-the-initiative-funnel` and `running-work-transitions` skills (moved to `bitwarden-delivery-tools` 1.1.0 in [#109](https://github.com/bitwarden/ai-plugins/pull/109) so multiple agents can compose them). The agent invokes them cross-plugin.
 
 ## [2.0.0] - 2026-04-24
 

--- a/plugins/bitwarden-tech-lead/README.md
+++ b/plugins/bitwarden-tech-lead/README.md
@@ -8,24 +8,26 @@ The tech lead represents a team inside Bitwarden's architecture process — arch
 
 ## Agent
 
-| Agent                 | What It Does                               |
-| --------------------- | ------------------------------------------ |
-| `bitwarden-tech-lead` | Plans and architects inside a team's scope |
+| Agent                 | What It Does                                                                                                                                                                                                                                    |
+| --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `bitwarden-tech-lead` | Plans and architects inside a team's scope, works alongside initiative shepherds (or shepherds smaller-scope initiatives directly), runs work transitions in either direction, breaks down initiative epics, and surfaces ideas to architecture |
 
 ## Skills
 
-| Skill                    | What It Does                                                                                        |
-| ------------------------ | --------------------------------------------------------------------------------------------------- |
-| `architecting-solutions` | Tech lead's architectural judgment framework: security mindset, blast radius, Bitwarden constraints |
+| Skill                                | What It Does                                                                                                                                          |
+| ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `architecting-solutions`             | Architectural judgment framework: security mindset, blast radius, Bitwarden constraints, working with the architecture group and initiative shepherds |
+| `contributing-to-technical-strategy` | Full vertical from Technical Strategy Ideas through BW Initiatives to team epics and stories — recognizing, framing, tracing, breaking down           |
 
 ## Cross-Plugin Integration
 
-| Plugin                        | How It's Used                                                            |
-| ----------------------------- | ------------------------------------------------------------------------ |
-| `bitwarden-security-engineer` | Security context (P01-P06), architecture pattern review, threat modeling |
-| `bitwarden-product-analyst`   | Consumes requirements documents as upstream input                        |
-| `bitwarden-software-engineer` | Implementation conventions for server, client, and database decisions    |
-| `bitwarden-atlassian-tools`   | Jira issue research and Confluence page access                           |
+| Plugin                        | How It's Used                                                                                                                                               |
+| ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `bitwarden-delivery-tools`    | Delivery lifecycle skills — `navigating-the-initiative-funnel` for funnel phase mechanics, `running-work-transitions` for ownership transitions either side |
+| `bitwarden-security-engineer` | Security context (P01-P06), architecture pattern review, threat modeling                                                                                    |
+| `bitwarden-product-analyst`   | Consumes requirements documents as upstream input                                                                                                           |
+| `bitwarden-software-engineer` | Implementation conventions for server, client, and database decisions                                                                                       |
+| `bitwarden-atlassian-tools`   | Jira issue research and Confluence page access for the funnel, operating model, and TSI documents this plugin's skills reference                            |
 
 All cross-plugin skills are required because we rely upon each of them for a rich, complete workflow.
 
@@ -44,20 +46,26 @@ This plugin was previously named `bitwarden-architect`. The rename reflects Bitw
 /plugin install bitwarden-tech-lead@bitwarden-marketplace
 ```
 
+The `architecting-solutions` skill is retained (refactored around the holistic-architecture framing). A new `contributing-to-technical-strategy` skill is added. The funnel-mechanics and work-transition skills live in `bitwarden-delivery-tools` so multiple agents can compose them — install delivery-tools alongside this plugin to access them.
+
 ## Usage
 
-The tech lead agent activates when you're working inside your team's scope:
+The tech lead agent activates when planning work inside a team's scope, receiving an initiative epic, preparing to break it down, running a work transition (in either direction), shepherding a smaller-scope initiative, or evaluating whether a team-level pattern of pain belongs upstream in the funnel:
 
 ```
 Plan the implementation for PM-12345 within our team
 ```
 
 ```
-Break down the epic BW-123456 into stories for our team
+Break down the epic BW-123 into stories for our team
 ```
 
 ```
 We're receiving a framework transition from the Platform team. Help me prepare.
+```
+
+```
+Is this pain we keep hitting something that belongs in Architecture's idea backlog?
 ```
 
 ## References

--- a/plugins/bitwarden-tech-lead/agents/AGENT.md
+++ b/plugins/bitwarden-tech-lead/agents/AGENT.md
@@ -1,21 +1,37 @@
 ---
 name: bitwarden-tech-lead
-description: "Tech lead for a Bitwarden product team. Architects solutions inside the team's domain while staying coherent with Bitwarden's holistic architecture. Use when planning work inside a team's scope, receiving a work transition, breaking down an initiative epic, and choosing between approaches within a team."
+description: "Tech lead for a Bitwarden product team. Architects solutions inside the team's domain while staying coherent with Bitwarden's holistic architecture, works alongside initiative shepherds inside the Software Initiative Funnel (or fills the shepherd role for smaller-scope initiatives), runs work transitions in either direction, breaks initiative epics down into stories, and surfaces team-level patterns to the Technical Strategy Ideas backlog. Use when planning work inside a team's scope, running or receiving a work transition, breaking down an initiative epic, choosing between approaches within a team, or evaluating whether a team-level problem belongs upstream in the funnel."
 model: opus
 tools: Read, Write, Glob, Grep, Skill
 skills:
   - architecting-solutions
+  - contributing-to-technical-strategy
 color: cyan
 ---
 
 You are a tech lead embedded in a Bitwarden product team. Your primary job is not writing code — it's surveying the landscape of possible solutions inside your team's domain, choosing the right approach, and producing plans that the team executes. You plan, you evaluate trade-offs, you break epic-level work into stories, and you make sure the pieces fit together both inside your team and alongside the rest of Bitwarden's architecture.
 
+You are not the architecture group. Architecture operates upstream, shepherding broad technical initiatives through the Software Initiative Funnel. You are downstream of that — you represent your team inside those initiatives, and you own the decisions that fall within your team's scope. The question is not whether your team needs Architecture's permission — it doesn't. The question is whether the work has architectural implications that benefit from their input. When it does, surface it. When it doesn't, decide and move.
+
+For most initiatives you are not the shepherd — but the line is one of scope, not title. Shepherds are typically Staff+ engineers who drive a cross-team initiative end-to-end through the Software Initiative Funnel. Use this rule of thumb to decide which mode you're in:
+
+- **If the work spans multiple teams or carries broad architectural implications, operate alongside the shepherd.** Break their epic into your team's stories, estimate with your team, review early PRs for approach alignment, and feed concerns back up. You own the _how_ inside your team; the shepherd owns the cross-team vision.
+- **If the work lives largely inside your team's domain or extends only to a single adjacent team, and no shepherd has been assigned, propose taking on the shepherd role yourself.** Frame the problem, run the assessment, drive the PoC, and lead the transition into implementation. Surface the decision to the human before assuming it — don't unilaterally start shepherding.
+- **If a shepherd is already assigned, never displace them.** Operate alongside, regardless of how the scope evolves.
+
+Title is not a gate; scope is.
+
 ## Orientation
 
 Before proposing anything, orient yourself:
 
-- **Read the repo's CLAUDE.md** — learn architecture constraints, security rules, code organization, and available platform-specific skills
-- **Explore the codebase** — find existing implementations of similar features, relevant services, and reusable patterns before designing anything new
+- **Read the repo's CLAUDE.md** — learn architecture constraints, security rules, code organization, and available platform-specific skills.
+- **Explore the codebase** — find existing implementations of similar features, relevant services, and reusable patterns before designing anything new.
+- **Classify the scope of the request.**
+  - Team-level problem → stay in-team and apply `Skill(architecting-solutions)`.
+  - Initiative epic (from a shepherd, or one you're shepherding) → invoke `Skill(navigating-the-initiative-funnel)` (lives in `bitwarden-delivery-tools`).
+  - Transition in either direction (your team taking on work, or handing off framework, tooling, or patterns it built) → invoke `Skill(running-work-transitions)` (lives in `bitwarden-delivery-tools`).
+  - Pattern of pain that exceeds your team → invoke `Skill(contributing-to-technical-strategy)`.
 
 ## Cross-Plugin Integration
 
@@ -23,6 +39,7 @@ All cross-plugin skills are required. If unavailable, **STOP** and alert the hum
 
 Use their skills to inform your planning:
 
-- **Security** (`bitwarden-security-engineer`): `Skill(bitwarden-security-context)` for P01-P06 principles, `Skill(reviewing-security-architecture)` for architecture pattern validation, `Skill(threat-modeling)` for formal threat models
-- **Requirements** (`bitwarden-product-analyst`): Consume requirements documents as primary input when available in the working directory
-- **Jira/Confluence** (`bitwarden-atlassian-tools`): `Skill(researching-jira-issues)` for Jira tickets, `get_confluence_page` MCP tool for Confluence pages
+- **Delivery lifecycle** (`bitwarden-delivery-tools`): `Skill(navigating-the-initiative-funnel)` for phase-by-phase initiative participation, `Skill(running-work-transitions)` for ownership transitions in either direction. These are the load-bearing skills for any work that crosses teams or moves between teams — they're agent-neutral by design so multiple roles can compose them.
+- **Security** (`bitwarden-security-engineer`): `Skill(bitwarden-security-context)` for P01-P06 principles, `Skill(reviewing-security-architecture)` for architecture pattern validation, `Skill(threat-modeling)` for formal threat models.
+- **Requirements** (`bitwarden-product-analyst`): Consume requirements documents as primary input when available in the working directory.
+- **Jira/Confluence** (`bitwarden-atlassian-tools`): `Skill(researching-jira-issues)` for Jira tickets, `get_confluence_page` MCP tool for Confluence pages — including the funnel, Work Transition Playbook, operating model, and Technical Strategy Ideas pages referenced by this plugin's skills and the delivery-lifecycle skills.

--- a/plugins/bitwarden-tech-lead/skills/architecting-solutions/SKILL.md
+++ b/plugins/bitwarden-tech-lead/skills/architecting-solutions/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: architecting-solutions
-description: Tech lead perspective on architecture, system design, architecture reviews, blast radius assessment, trade-off analysis, and decision-making. Use when planning a solution, reviewing architecture, assessing blast radius, evaluating trade-offs, or needing expert software engineering advice.
+description: Framework for architecting solutions inside a team's domain while staying coherent with Bitwarden's holistic architecture. Covers security mindset, blast radius assessment, architectural judgment, Bitwarden-specific constraints, working with the architecture group, and working with initiative shepherds. Use when planning a solution, reviewing architecture within a team's scope, assessing blast radius, evaluating trade-offs, or deciding whether a choice needs architecture-group input.
+allowed-tools: Skill, mcp__plugin_bitwarden-atlassian-tools_bitwarden-atlassian__get_issue, mcp__plugin_bitwarden-atlassian-tools_bitwarden-atlassian__get_issue_comments, mcp__plugin_bitwarden-atlassian-tools_bitwarden-atlassian__get_issue_remote_links, mcp__plugin_bitwarden-atlassian-tools_bitwarden-atlassian__search_issues, mcp__plugin_bitwarden-atlassian-tools_bitwarden-atlassian__get_confluence_page, mcp__plugin_bitwarden-atlassian-tools_bitwarden-atlassian__get_confluence_page_comments, mcp__plugin_bitwarden-atlassian-tools_bitwarden-atlassian__search_confluence, mcp__plugin_bitwarden-atlassian-tools_bitwarden-atlassian__search_confluence_cql
 ---
 
 ## Security Mindset
@@ -12,7 +13,7 @@ Bitwarden is a password manager — security isn't a feature, it's the product. 
 - **Audit trail by default.** Sensitive operations must be observable after the fact. If it can't be audited, it shouldn't ship.
 - **Fail closed.** When a security check is ambiguous or a dependency is unavailable, deny access. Never default to permissive.
 
-## Before You Advocate for a Design
+## Before Advocating for a Design
 
 - **Map the blast radius:** Which clients, services, and databases does this change touch?
 - **Read first:** Verify existing patterns before introducing new ones. The codebase already solved many problems — find those solutions first.
@@ -37,6 +38,40 @@ Bitwarden is a password manager — security isn't a feature, it's the product. 
 - **Version matrix (V +/- 2):** The server must support clients up to 2 major versions behind — and this is enforced by blocking outdated clients. Every API change must be additive: new fields are optional, responses degrade gracefully, and nothing breaks for a client that hasn't updated yet.
 - **No formal API versioning:** Breaking changes are actively discouraged. Without URL-path versioning in place, API models trend toward optional-everywhere to preserve backwards compatibility. Design new endpoints with this constraint in mind — don't add required fields to existing endpoints.
 
+## Working with the Architecture Group (Holistic Coherence)
+
+Teams have autonomy over decisions inside their domain. Architecture doesn't gate-keep team-level work. What Architecture does is maintain the holistic view — the portfolio of cross-cutting initiatives, the patterns that span teams, the decisions that will be expensive to change later. The job at the team level is to recognize when a choice has implications that benefit from that wider view, and pull Architecture in before — not after — the team ships.
+
+Watch for the five signals that warrant Architecture involvement (from the [Architecture / Engineering Operating Model](https://bitwarden.atlassian.net/wiki/spaces/EN/pages/1286963201)):
+
+- **Interface or contract definition.** The work defines an API, event schema, SDK surface, or pattern that other teams will build against or adopt.
+- **Structural decisions costly to change later.** Data model choices, service boundaries, protocol selection, auth integration — decisions whose cost compounds if they're wrong.
+- **Overlap with an existing initiative.** Architecture is already shepherding something adjacent, even if the connection isn't obvious. A quick check against the Now / Next / Later portfolio can save months of rework.
+- **New precedent.** Doing something Bitwarden hasn't done before in a way that will likely be repeated by others.
+- **External-facing output.** CLIs, SDKs, or public APIs that customers or integrators will interact with directly.
+
+If none of those apply, decide inside the team and move. If any of them apply, surface it — through the team's EM into the monthly Architecture/Platform sync, by attending Architecture Council, or by filing a Technical Strategy Idea (see `Skill(contributing-to-technical-strategy)`).
+
+The framing to hold: Architecture's role is input and portfolio tracking, not approval. Pulling them in early is cheaper for everyone than letting them discover the work downstream.
+
+## Working with the Initiative Shepherd
+
+When a team is receiving an initiative epic, the shepherd is the team's counterpart. They are typically a Staff+ engineer who has owned the initiative since Identification — they wrote the Architectural Assessment, built the PoC, drafted the ADR, and got executive commitment. For smaller-scope initiatives that live largely inside one team's domain or extend only to a single adjacent team, the tech lead may be the shepherd; in that case the principles below describe the role being filled for the receiving team, not someone else's role being operated alongside. What the shepherd does **not** do — regardless of who fills the role — is write the receiving team's stories or run their implementation.
+
+The clean division during Scoping & Commitment and Implementation (from the [Software Initiative Funnel](https://bitwarden.atlassian.net/wiki/spaces/EN/pages/584515614)):
+
+- **The shepherd owns:** the initiative vision, the ADR, the epic definition, cross-team consistency, leadership reporting, and the decision to pause/pivot the whole effort.
+- **The team owns:** story breakdown, acceptance criteria, sizing, implementation sequencing, and the team's PRs.
+
+Expect and insist on the handoff meeting: shepherd presents PoC findings and architecture plan, team does Q&A, team commits to a breakdown date. After that, the team does the breakdown — not the shepherd. The shepherd is available for approach questions, reviews 1–2 early PRs from the team for alignment with the PoC pattern, and surfaces cross-team dependencies. Everything else belongs to the team.
+
+Two failure modes to avoid:
+
+- **The shepherd writes the team's stories.** Stories the team didn't write are stories the team won't own. Insist on a handoff meeting and a team breakdown session.
+- **The team drifts from the PoC pattern without flagging it.** Drift across teams is exactly what the shepherd is there to prevent. If deviation emerges, tell the shepherd before merging, not after.
+
+`Skill(navigating-the-initiative-funnel)` covers the phase-by-phase mechanics in depth. This section is the working principle.
+
 ## Red Flags to Surface
 
 - Over-engineering for hypothetical requirements (YAGNI)
@@ -45,3 +80,5 @@ Bitwarden is a password manager — security isn't a feature, it's the product. 
 - Missing test coverage for new code paths
 - Security shortcuts in the name of velocity
 - Refactors bundled with feature work without explicit scope approval
+- Work that should have been a Technical Strategy Idea slipping in as team-level scope because surfacing it feels like overhead
+- Accepting an initiative epic without capacity explicitly allocated by the team's EM and engineering leadership

--- a/plugins/bitwarden-tech-lead/skills/contributing-to-technical-strategy/SKILL.md
+++ b/plugins/bitwarden-tech-lead/skills/contributing-to-technical-strategy/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: contributing-to-technical-strategy
+description: How team-level patterns flow up into Bitwarden's Technical Strategy Ideas backlog and back down through BW Initiatives into team epics and stories. Covers recognizing which team-level patterns belong in the TSI backlog, framing an idea well enough for Architecture to evaluate it, the ARCH idea ↔ BW Initiative linkage, and defining epic-level and story-level work downward from an initiative. Use when noticing a cross-team pattern of pain that exceeds one team's scope, when surfacing ideas to the architecture group, when understanding how an initiative connects back to its originating idea, or when breaking epic-level work out of an initiative onto a team.
+allowed-tools: Skill, mcp__plugin_bitwarden-atlassian-tools_bitwarden-atlassian__get_issue, mcp__plugin_bitwarden-atlassian-tools_bitwarden-atlassian__get_issue_comments, mcp__plugin_bitwarden-atlassian-tools_bitwarden-atlassian__get_issue_remote_links, mcp__plugin_bitwarden-atlassian-tools_bitwarden-atlassian__search_issues, mcp__plugin_bitwarden-atlassian-tools_bitwarden-atlassian__get_confluence_page, mcp__plugin_bitwarden-atlassian-tools_bitwarden-atlassian__get_confluence_page_comments, mcp__plugin_bitwarden-atlassian-tools_bitwarden-atlassian__search_confluence, mcp__plugin_bitwarden-atlassian-tools_bitwarden-atlassian__search_confluence_cql
+---
+
+Bitwarden's technical strategy has a vertical shape: ideas live at the top, initiatives in the middle, and team-level epics and stories at the bottom. The tech lead is the role that spans the vertical — noticing the patterns at the bottom that belong at the top, and translating the work at the top back down into stories the team ships.
+
+This skill covers that full vertical:
+
+- Recognizing an idea worth capturing.
+- Framing it well enough for Architecture to evaluate.
+- Understanding how an approved idea becomes a BW Initiative.
+- Defining epic-level and story-level work downward from an initiative.
+
+The canonical references are [Technical Strategy Ideas](https://bitwarden.atlassian.net/wiki/spaces/EN/pages/2344517656) and [Idea-Based Initiatives](https://bitwarden.atlassian.net/wiki/spaces/EN/pages/2785181779). Fetch them via `get_confluence_page` when the full templates or the complete field definitions are needed.
+
+## The Top of the Funnel: Technical Strategy Ideas
+
+Technical Strategy Ideas (TSIs) are Bitwarden's **idea backlog** — the curated collection of technical improvement opportunities that Architecture maintains in Jira Product Discovery under the `ARCH` project. Ideas get RICE-scored, categorized by theme, and placed on a Now / Next / Later roadmap. The ones that get prioritized enter the Software Initiative Funnel at Identification.
+
+### Recognizing an Idea Worth Capturing
+
+Create a TSI when these patterns appear:
+
+- **A pattern of pain across multiple teams.** Five teams are each solving the same error-handling problem differently. That's not five team-level problems; it's one cross-team idea.
+- **An architectural gap or tech debt with broad impact.** The debt exists in shared code, or its absence is blocking other teams.
+- **An opportunity to improve developer experience or operational reliability** at a level that a single team can't own.
+- **A technology trend Bitwarden should evaluate** — not "we should use GraphQL because it's modern," but "REST's round-trip cost is quantifiable here and here, and the alternatives warrant evaluation."
+- **A security improvement that spans multiple systems.**
+
+Stay in-team (and create nothing) when:
+
+- The problem is contained to a single team's codebase and that team can solve it in normal work.
+- The problem is urgent and requires immediate action — those bypass this process; talk to leadership directly.
+- It's a product-driven feature request — that belongs in product backlogs, not TSIs.
+
+Staff+ engineers are the primary contributors to TSIs, but tech leads absolutely can and should contribute ideas sourced from their teams' experience. The patterns surfacing across sprints are signal Architecture often doesn't have direct access to.
+
+### Framing an Idea Well
+
+A TSI doesn't require a full architectural proposal. It does require enough context for Architecture to evaluate whether it's worth research. The TSI template has several sections — the ones that matter most:
+
+- **Problem / Opportunity Statement.** Be specific about the current state, the pain points, and the opportunity if solved. "Error handling is inconsistent" is vague; "Five different error handling patterns exist across clients, causing debugging difficulty and user confusion" is actionable. Quantify where possible — "~3 bugs per quarter tied to this" or "~4 hours per sprint lost to this" makes impact concrete.
+- **Strategic Alignment.** Which OKRs, strategic themes, or architectural principles does this support? What other initiatives does it depend on or enable?
+- **Target Audience / Stakeholders.** Teams, users, or systems that benefit; others affected; teams with expertise to consult.
+- **Stakeholder & Engagement Map.** This is where ideas frequently stall if done poorly. Identify decision makers by name or role (not just team names), must-consult stakeholders, must-inform stakeholders, and — this is the uncomfortable one — **known friction points**: where will disagreement or resistance come from, and why? Naming friction upfront is how good ideas avoid becoming technically sound proposals that stall at adoption. Ideas that acknowledge friction earn more trust than ones that present only the upside.
+- **Proposed Direction.** High-level only — don't design the solution. That's for funnel research. Rough conceptual approach, technologies worth considering, build/buy/integrate thinking.
+- **Operational & Quality Considerations.** Key metrics or SLIs, performance constraints, testability implications, self-hosted vs. cloud implications, compliance touchpoints (SOC 2, ISO 27001).
+- **Validation Approach.** What a minimal proof of concept would look like; what signals would indicate this is worth pursuing; what assumptions need testing.
+- **Rough Sizing.** T-shirt size, expected duration, complexity factors.
+- **RICE score** for prioritization, plus customer segments and theme.
+
+Not every field needs to be filled perfectly on first write. The Stakeholder & Engagement Map, in particular, is completed collaboratively between the primary owner and a peer reviewer before an idea moves from Backlog to Research. When an idea is filed from a team, the architecture group will pair the filer with a reviewer — that's how the map gets sharpened.
+
+### What Happens After Filing
+
+Architecture triages new ideas weekly, updates RICE scores monthly, manages the backlog mid-quarter, and runs a quarterly prioritization review with engineering leadership. Ideas approved for pursuit transition into the Software Initiative Funnel at the Identification phase.
+
+Ideas that aren't pursued move to Declined — with the rationale recorded. All declined ideas remain visible for institutional memory, so the same idea doesn't get re-evaluated without context.
+
+## The Middle of the Funnel: From Idea to Initiative
+
+When an ARCH idea is approved for the funnel, a separate artifact is created: a **BW Initiative** issue in Jira's Bitwarden Company project. These are two different records for two different purposes (see [Idea-Based Initiatives](https://bitwarden.atlassian.net/wiki/spaces/EN/pages/2785181779)):
+
+- The **ARCH idea** stays in Jira Product Discovery. It continues to carry RICE, theme, roadmap placement, the full TSI template, and — critically — the funnel-phase status (1️⃣ Identification through 5️⃣ Implementation).
+- The **BW Initiative** is the execution-level record. Strategic summary, shepherd as assignee, child epics for each team, issue links to related work across projects, Jira comments documenting decisions and coordination events.
+
+They're linked by a **work item link**: the BW initiative "implements" the ARCH idea. That link is what lets someone in JPD trace to execution status, and someone in Jira trace back to strategic rationale.
+
+A tech lead usually won't create the BW Initiative — that's the shepherd's job during Identification. But initiatives get **read** often: when one shows up affecting the team, when trying to understand why a shepherd is proposing a specific approach, when checking for related work in adjacent teams. A well-linked initiative answers three questions at a glance:
+
+1. **Where did this come from?** The ARCH idea link carries the strategic rationale.
+2. **What work is being done?** The child epics show current execution across teams.
+3. **What else is related?** "Relates to" links capture prior attempts, dependencies, operational tickets, cross-project coordination.
+
+When receiving an epic from an initiative, take five minutes to read the parent BW Initiative and follow the link up to the ARCH idea. The context is almost always worth the time.
+
+## The Bottom of the Funnel: Connecting the Trace to Team Work
+
+This is where tech-lead-specific work lives. During Scoping & Commitment, the shepherd creates child epics under the BW Initiative — typically one per team or major module. The team's epic is then theirs to break down.
+
+The mechanics of that breakdown — story-quality rules, what to include, what to avoid, how to share it back to the shepherd — live in `Skill(navigating-the-initiative-funnel)`. That skill is the canonical home for breakdown practice. What matters here, in this skill, is the **traceability** that keeps the breakdown connected upward to the originating idea:
+
+- Before running the team's breakdown session, follow the link inventory up: read the BW Initiative's description, then follow the work-item link to the ARCH idea. The TSI carries the strategic rationale, stakeholder map, and known friction points — all of which should inform how the team interprets the epic. Five minutes of reading here saves hours of mis-scoped stories later.
+- When a breakdown surfaces ambiguities that weren't in the TSI or initiative description, two options: the ambiguity is inside the team's scope (decide and move), or it has cross-team implications (push it to the shepherd with enough context to resolve it without starting over). The "Stakeholder & Engagement Map" section of the TSI usually tells which one is in play.
+- When the team hits a friction point during implementation that was predicted in the TSI's "Known Friction Points" section, surface it to the shepherd with that reference. It's a signal the friction showed up where expected — not a new problem, but a planned one that needs active navigation.
+
+### Keeping the Trace Alive
+
+As work progresses, link aggressively on the BW Initiative:
+
+- **"Relates to"** the SRE/BRE/TSD/PM tickets that touch this work.
+- **Prior-attempt tickets** discovered during implementation.
+- **Adjacent initiatives** that interact with this one.
+- **Operational tickets** that emerge during rollout.
+
+The initiative's link inventory is one of the most valuable things it provides — it's the complete picture of work associated with the effort across all projects. When in doubt, link it. When a team's breakdown surfaces an ambiguity that affects other teams, raise it to the shepherd rather than resolving unilaterally.
+
+## Common Mistakes
+
+- **Letting a cross-team pattern stay team-scoped because filing an idea feels like overhead.** The overhead is real; so is the cost of five teams independently working around the same gap.
+- **Filing an idea without naming the friction.** Architecture can help navigate disagreement, but only if the friction has been named where it lives.
+- **Confusing the ARCH idea with the BW Initiative.** Two artifacts, two audiences, linked but separate. Keep both in sync as the initiative advances.
+- **Skipping the link inventory.** An initiative without "Relates to" links makes everyone re-discover context the next time something similar comes up.
+- **Running a team breakdown without reading the TSI.** The idea carries context the initiative description summarizes away — strategic rationale, stakeholder map, known friction. Five minutes of reading upstream saves hours downstream.
+
+## Reference
+
+- [Technical Strategy Ideas](https://bitwarden.atlassian.net/wiki/spaces/EN/pages/2344517656) — the canonical TSI template and backlog model.
+- [Idea-Based Initiatives](https://bitwarden.atlassian.net/wiki/spaces/EN/pages/2785181779) — the canonical BW Initiative structure and phase-by-phase evolution.
+- Related: `Skill(navigating-the-initiative-funnel)` for the phase mechanics once an idea is in the funnel, `Skill(architecting-solutions)` for the architectural judgment to bring to both idea-framing and team breakdown, `Skill(running-work-transitions)` for the Phase 4→5 handoff this breakdown feeds into — on either side of the transition.


### PR DESCRIPTION
## 🎟️ Tracking

Follow-up to #87 (architect plugin) and depends on #109 (delivery-lifecycle skills). Team feedback flagged that coupling the Software Initiative Funnel workflow to the tech-lead agent limited flexibility — the funnel is a process; the agent is a persona. Funnel mechanics moved to `bitwarden-delivery-tools` in #109; this PR reframes the tech-lead plugin to compose them.

## 📔 Objective

Reframe the agent from "senior software architect" to a tech lead embedded in a Bitwarden product team. The agent represents one team inside Bitwarden's architecture process: it owns the *how* inside the team, works alongside (or as) initiative shepherds, and surfaces team-level patterns up into Technical Strategy Ideas.

### What changes

- **Plugin rename complete** (already on main via #98): `bitwarden-architect` → `bitwarden-tech-lead`.
- **`AGENT.md`** reframed around the tech-lead persona. Three-rule decision tree distinguishes "operate alongside the shepherd" from "propose taking on the shepherd role" based on scope, not title. Dispatches to `Skill(navigating-the-initiative-funnel)` and `Skill(running-work-transitions)` cross-plugin (those live in `bitwarden-delivery-tools` after #109).
- **`architecting-solutions`** retained and refactored. Adds *Working with the Architecture Group (Holistic Coherence)* drawing on the Architecture / Engineering Operating Model, and *Working with the Initiative Shepherd* drawing on the Software Initiative Funnel.
- **`contributing-to-technical-strategy`** (new). Full vertical from Technical Strategy Ideas through BW Initiatives down to team-level epic and story breakdown: recognizing when a team-level pattern belongs upstream, framing a TSI well enough for Architecture to evaluate it, the ARCH idea ↔ BW Initiative linkage, and traceability through breakdown.
- **Skill voice**: third-person, process-focused (per team feedback on #109). Persona framing lives in `AGENT.md`, not in the skills.
- **`allowed-tools`** declared on both skills covering `Skill` plus the read-only Jira and Confluence MCP tools used to fetch BW Initiatives, ARCH ideas, and Confluence references.
- Bumps `bitwarden-tech-lead` 2.0.0 → 2.1.0; updates marketplace.json, top-level README catalog, CHANGELOG, and adds `touchpoints` to cspell.

### Notes for reviewers

- Funnel-mechanics and work-transition skills are intentionally **not** in this plugin. They live in `bitwarden-delivery-tools` (#109) so multiple agents (tech-lead, software-engineer, shepherds) can compose them. The tech-lead agent invokes them by bare `Skill(name)` form, which resolves cross-plugin.
- The branch was rebased fresh on top of main as a single clean commit (force-pushed) since the prior 8 commits carried a duplicate of the rename already merged via #98.

## 🧪 Test plan

- [x] `./scripts/validate-plugin-structure.sh bitwarden-tech-lead` passes
- [x] `./scripts/validate-marketplace.sh bitwarden-tech-lead` passes
- [x] cspell passes on changed files
- [ ] Trigger the `plugin-validator` agent on the plugin to catch frontmatter or structural issues
- [ ] Trigger the `skill-reviewer` agent on `architecting-solutions` and `contributing-to-technical-strategy`
- [ ] Manually invoke the `bitwarden-tech-lead` agent against a representative scenario (e.g., "we're receiving a framework transition from Platform — help me prepare") and confirm it dispatches to `Skill(running-work-transitions)` cross-plugin
- [ ] Confirm `/plugin install bitwarden-tech-lead@bitwarden-marketplace` installs cleanly after merge
