### PR TITLE
feat: Add bitwarden-delivery-tools plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -69,6 +69,12 @@
       "source": "./plugins/bitwarden-architect",
       "version": "1.0.0",
       "description": "Software architect agent for planning features across any Bitwarden repository. Discovers platform context dynamically via CLAUDE.md and repo-local planning skills."
+    },
+    {
+      "name": "bitwarden-delivery-tools",
+      "source": "./plugins/bitwarden-delivery-tools",
+      "version": "1.0.0",
+      "description": "Delivery workflow skills for committing, PR creation, preflight checks, and change labeling across any Bitwarden repository."
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A curated collection of plugins for AI-assisted development at Bitwarden. Enable
 | [bitwarden-architect](plugins/bitwarden-architect/)                 | 1.0.0   | Software architect for technical planning, architecture reviews, and implementation phasing                         |
 | [bitwarden-atlassian-tools](plugins/bitwarden-atlassian-tools/)     | 2.2.3   | Read-only Atlassian access via MCP server with deep Jira issue research skill                                       |
 | [bitwarden-code-review](plugins/bitwarden-code-review/)             | 1.9.1   | Autonomous code review agent following Bitwarden engineering standards with GitHub integration                      |
+| [bitwarden-delivery-tools](plugins/bitwarden-delivery-tools/)       | 1.0.0   | Generic delivery workflow skills for committing, PR creation, preflight checks, and change labeling                 |
 | [bitwarden-devops-engineer](plugins/bitwarden-devops-engineer/)     | 0.1.1   | DevOps engineering assistant: workflow compliance linting, action security auditing, and org-wide CI/CD remediation |
 | [bitwarden-init](plugins/bitwarden-init/)                           | 1.1.0   | Initialize and enhance CLAUDE.md files with Bitwarden's standardized template format                                |
 | [bitwarden-product-analyst](plugins/bitwarden-product-analyst/)     | 0.1.5   | Product analyst agent for creating comprehensive Bitwarden requirements documents from multiple sources             |

--- a/plugins/bitwarden-delivery-tools/.claude-plugin/plugin.json
+++ b/plugins/bitwarden-delivery-tools/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "bitwarden-delivery-tools",
+  "version": "1.0.0",
+  "description": "Delivery workflow skills for committing, PR creation, preflight checks, and change labeling across any Bitwarden repository.",
+  "author": {
+    "name": "Bitwarden",
+    "url": "https://github.com/bitwarden"
+  },
+  "homepage": "https://github.com/bitwarden/ai-marketplace/tree/main/plugins/bitwarden-delivery-tools",
+  "repository": "https://github.com/bitwarden/ai-marketplace",
+  "keywords": ["delivery", "commit", "pull-request", "preflight", "labeling"]
+}

--- a/plugins/bitwarden-delivery-tools/.claude-plugin/plugin.json
+++ b/plugins/bitwarden-delivery-tools/.claude-plugin/plugin.json
@@ -6,7 +6,7 @@
     "name": "Bitwarden",
     "url": "https://github.com/bitwarden"
   },
-  "homepage": "https://github.com/bitwarden/ai-marketplace/tree/main/plugins/bitwarden-delivery-tools",
-  "repository": "https://github.com/bitwarden/ai-marketplace",
+  "homepage": "https://github.com/bitwarden/ai-plugins/tree/main/plugins/bitwarden-delivery-tools",
+  "repository": "https://github.com/bitwarden/ai-plugins",
   "keywords": ["delivery", "commit", "pull-request", "preflight", "labeling"]
 }

--- a/plugins/bitwarden-delivery-tools/CHANGELOG.md
+++ b/plugins/bitwarden-delivery-tools/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to the `bitwarden-delivery-tools` plugin will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0] - 2026-04-08
+
+### Added
+
+- Generic `committing-changes` skill for commit message format and staging workflow
+- Generic `creating-pull-request` skill for PR creation and draft workflow
+- Generic `labeling-changes` skill for conventional commit type keywords and label mapping
+- Generic `perform-preflight` skill for pre-commit quality gate checklist
+- All skills are platform-agnostic and reference the repo's CLAUDE.md for platform-specific details

--- a/plugins/bitwarden-delivery-tools/README.md
+++ b/plugins/bitwarden-delivery-tools/README.md
@@ -21,4 +21,26 @@ Each skill owns the **workflow** (what steps to follow, what format to use). The
 
 ## Installation
 
-Install via the Bitwarden AI Marketplace.
+```bash
+/plugin install bitwarden-delivery-tools@bitwarden-marketplace
+```
+
+## Usage
+
+Skills activate based on natural-language triggers during your delivery workflow:
+
+```
+Commit these changes
+```
+
+```
+Create a PR for this branch
+```
+
+```
+Run preflight before I commit
+```
+
+```
+What change type should I use for this PR?
+```

--- a/plugins/bitwarden-delivery-tools/README.md
+++ b/plugins/bitwarden-delivery-tools/README.md
@@ -1,0 +1,24 @@
+# Bitwarden Delivery Tools
+
+Generic delivery workflow skills for committing, PR creation, preflight checks, and change labeling across any Bitwarden repository.
+
+## Overview
+
+These skills define the delivery **process** — commit formats, PR workflows, quality gates, and labeling conventions. Platform-specific details (build commands, lint tools, test runners) are discovered dynamically from each repo's CLAUDE.md.
+
+## Skills
+
+| Skill                   | Triggers                   | Purpose                                                |
+| ----------------------- | -------------------------- | ------------------------------------------------------ |
+| `committing-changes`    | "commit", "stage changes"  | Commit message format, staging best practices          |
+| `creating-pull-request` | "create PR", "open PR"     | PR title/body format, draft workflow, AI review labels |
+| `labeling-changes`      | "label", "change type"     | Conventional commit type keywords, CI label mapping    |
+| `perform-preflight`     | "preflight", "self review" | Pre-commit quality gate checklist                      |
+
+## Design Principle
+
+Each skill owns the **workflow** (what steps to follow, what format to use). The repo's CLAUDE.md owns the **platform specifics** (which linter to run, which test command to use, which security rules apply). This separation allows the same skills to work across Android, iOS, Server, SDK, and Clients repos.
+
+## Installation
+
+Install via the Bitwarden AI Marketplace.

--- a/plugins/bitwarden-delivery-tools/references/change-type-labels.md
+++ b/plugins/bitwarden-delivery-tools/references/change-type-labels.md
@@ -1,0 +1,34 @@
+# Change Type Labels
+
+Conventional commit type keywords used in commit messages and PR titles. Each keyword drives automatic `t:` label assignment via CI (`.github/scripts/label-pr.py` reads `.github/label-pr.json`). CI matches `<type>:` or `<type>(` in the lowercased title.
+
+## Type Keywords
+
+| Type           | Label               | Use for                                    |
+| -------------- | ------------------- | ------------------------------------------ |
+| `feat`         | `t:feature`         | New features or functionality              |
+| `fix`          | `t:bug`             | Bug fixes                                  |
+| `refactor`     | `t:tech-debt`       | Code restructuring without behavior change |
+| `chore`        | `t:tech-debt`       | Maintenance, cleanup, minor tweaks         |
+| `test`         | `t:tech-debt`       | Adding or updating tests                   |
+| `perf`         | `t:tech-debt`       | Performance improvements                   |
+| `docs`         | `t:docs`            | Documentation changes                      |
+| `ci` / `build` | `t:ci`              | CI/CD and build system changes             |
+| `deps`         | `t:deps`            | Dependency updates                         |
+| `llm`          | `t:llm`             | LLM/Claude configuration changes           |
+| `breaking`     | `t:breaking-change` | Breaking changes requiring migration       |
+| `misc`         | `t:misc`            | Changes that do not fit other categories   |
+
+CI also accepts additional aliases (e.g., `revert`, `bugfix`, `cleanup`). See `.github/label-pr.json` for the full mapping.
+
+## Selecting a Type
+
+Infer the type from the task description and changes made. **If the type cannot be confidently determined, ask the user.**
+
+### Ambiguous Cases
+
+- Refactor that incidentally fixes a bug → use the **primary intent**: `fix:` if the bug was the goal, `refactor:` if the restructuring was the goal
+- Adding tests for existing untested code → `test:` (not `chore:`)
+- Updating a dependency to fix a vulnerability → `deps:` (not `fix:`)
+- Changing Claude/LLM configuration files → `llm:` (not `chore:`)
+- Removing dead code → `refactor:` (not `chore:` — it changes the codebase structure)

--- a/plugins/bitwarden-delivery-tools/skills/committing-changes/SKILL.md
+++ b/plugins/bitwarden-delivery-tools/skills/committing-changes/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: committing-changes
+description: Git commit conventions and workflow for Bitwarden repositories. Use when committing code, writing commit messages, or preparing changes for commit. Triggered by "commit", "git commit", "commit message", "prepare commit", "stage changes".
+---
+
+# Git Commit Conventions
+
+## Commit Message Format
+
+```
+[PM-XXXXX] <type>: <imperative summary>
+
+<optional body explaining why, not what>
+```
+
+### Rules
+
+1. **Ticket prefix**: Always include `[PM-XXXXX]` matching the Jira ticket
+2. **Type keyword**: Select from the table below. The keyword drives automatic `t:` label assignment via CI (`.github/scripts/label-pr.py` reads `.github/label-pr.json`). CI matches `<type>:` or `<type>(` in the lowercased title.
+
+| Type           | Label               | Use for                                    |
+| -------------- | ------------------- | ------------------------------------------ |
+| `feat`         | `t:feature`         | New features or functionality              |
+| `fix`          | `t:bug`             | Bug fixes                                  |
+| `refactor`     | `t:tech-debt`       | Code restructuring without behavior change |
+| `chore`        | `t:tech-debt`       | Maintenance, cleanup, minor tweaks         |
+| `test`         | `t:tech-debt`       | Adding or updating tests                   |
+| `perf`         | `t:tech-debt`       | Performance improvements                   |
+| `docs`         | `t:docs`            | Documentation changes                      |
+| `ci` / `build` | `t:ci`              | CI/CD and build system changes             |
+| `deps`         | `t:deps`            | Dependency updates                         |
+| `llm`          | `t:llm`             | LLM/Claude configuration changes           |
+| `breaking`     | `t:breaking-change` | Breaking changes requiring migration       |
+| `misc`         | `t:misc`            | Changes that do not fit other categories   |
+
+CI also accepts aliases (e.g., `revert`, `bugfix`, `cleanup`). See `.github/label-pr.json` for the full mapping. **If the type cannot be confidently determined, ask the user.**
+
+### Examples
+
+```
+[PM-12345] feat: Add biometric unlock timeout configuration
+
+Users reported confusion about when biometric prompts appear.
+This adds a configurable timeout setting to the security preferences.
+```
+
+Ambiguous cases — choosing between similar types:
+
+```
+# Refactor that also fixes a bug? Use the primary intent:
+[PM-12345] fix: Resolve null pointer in vault sync retry logic
+
+# Test-only change:
+[PM-12345] test: Add unit tests for biometric timeout edge cases
+```
+
+### Followup Commits
+
+Only the first commit on a branch needs the full format (ticket prefix, type keyword, body). Subsequent commits can use a short, descriptive summary with no prefix or body required.
+
+```
+Update error handling in login flow
+```
+
+---
+
+## Pre-Commit Quality Gate
+
+Before staging, run the `perform-preflight` skill for the full quality gate checklist (tests, lint, security, architecture). Consult the repo's CLAUDE.md for platform-specific build and lint commands.

--- a/plugins/bitwarden-delivery-tools/skills/committing-changes/SKILL.md
+++ b/plugins/bitwarden-delivery-tools/skills/committing-changes/SKILL.md
@@ -16,24 +16,7 @@ description: Git commit conventions and workflow for Bitwarden repositories. Use
 ### Rules
 
 1. **Ticket prefix**: Always include `[PM-XXXXX]` matching the Jira ticket
-2. **Type keyword**: Select from the table below. The keyword drives automatic `t:` label assignment via CI (`.github/scripts/label-pr.py` reads `.github/label-pr.json`). CI matches `<type>:` or `<type>(` in the lowercased title.
-
-| Type           | Label               | Use for                                    |
-| -------------- | ------------------- | ------------------------------------------ |
-| `feat`         | `t:feature`         | New features or functionality              |
-| `fix`          | `t:bug`             | Bug fixes                                  |
-| `refactor`     | `t:tech-debt`       | Code restructuring without behavior change |
-| `chore`        | `t:tech-debt`       | Maintenance, cleanup, minor tweaks         |
-| `test`         | `t:tech-debt`       | Adding or updating tests                   |
-| `perf`         | `t:tech-debt`       | Performance improvements                   |
-| `docs`         | `t:docs`            | Documentation changes                      |
-| `ci` / `build` | `t:ci`              | CI/CD and build system changes             |
-| `deps`         | `t:deps`            | Dependency updates                         |
-| `llm`          | `t:llm`             | LLM/Claude configuration changes           |
-| `breaking`     | `t:breaking-change` | Breaking changes requiring migration       |
-| `misc`         | `t:misc`            | Changes that do not fit other categories   |
-
-CI also accepts aliases (e.g., `revert`, `bugfix`, `cleanup`). See `.github/label-pr.json` for the full mapping. **If the type cannot be confidently determined, ask the user.**
+2. **Type keyword**: See [Change Type Labels](../../references/change-type-labels.md) for the full table of conventional commit types and their CI label mappings. **If the type cannot be confidently determined, ask the user.**
 
 ### Examples
 

--- a/plugins/bitwarden-delivery-tools/skills/committing-changes/SKILL.md
+++ b/plugins/bitwarden-delivery-tools/skills/committing-changes/SKILL.md
@@ -16,7 +16,7 @@ description: Git commit conventions and workflow for Bitwarden repositories. Use
 ### Rules
 
 1. **Ticket prefix**: Always include `[PM-XXXXX]` matching the Jira ticket
-2. **Type keyword**: See [Change Type Labels](../../references/change-type-labels.md) for the full table of conventional commit types and their CI label mappings. **If the type cannot be confidently determined, ask the user.**
+2. **Type keyword**: Read `${CLAUDE_PLUGIN_ROOT}/references/change-type-labels.md` for the full table of conventional commit types and their CI label mappings. **If the type cannot be confidently determined, ask the user.**
 
 ### Examples
 

--- a/plugins/bitwarden-delivery-tools/skills/creating-pull-request/SKILL.md
+++ b/plugins/bitwarden-delivery-tools/skills/creating-pull-request/SKILL.md
@@ -11,22 +11,7 @@ description: Pull request creation workflow for Bitwarden repositories. Use when
 [PM-XXXXX] <type>: <short imperative summary>
 ```
 
-**Type keywords** (triggers automatic `t:` label via CI):
-
-| Type           | Label               | Use for                                    |
-| -------------- | ------------------- | ------------------------------------------ |
-| `feat`         | `t:feature`         | New features or functionality              |
-| `fix`          | `t:bug`             | Bug fixes                                  |
-| `refactor`     | `t:tech-debt`       | Code restructuring without behavior change |
-| `chore`        | `t:tech-debt`       | Maintenance, cleanup, minor tweaks         |
-| `test`         | `t:tech-debt`       | Adding or updating tests                   |
-| `perf`         | `t:tech-debt`       | Performance improvements                   |
-| `docs`         | `t:docs`            | Documentation changes                      |
-| `ci` / `build` | `t:ci`              | CI/CD and build system changes             |
-| `deps`         | `t:deps`            | Dependency updates                         |
-| `llm`          | `t:llm`             | LLM/Claude configuration changes           |
-| `breaking`     | `t:breaking-change` | Breaking changes requiring migration       |
-| `misc`         | `t:misc`            | Changes that do not fit other categories   |
+**Type keywords** (triggers automatic `t:` label via CI): see [Change Type Labels](../../references/change-type-labels.md) for the full table.
 
 **Examples:**
 

--- a/plugins/bitwarden-delivery-tools/skills/creating-pull-request/SKILL.md
+++ b/plugins/bitwarden-delivery-tools/skills/creating-pull-request/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: creating-pull-request
+description: Pull request creation workflow for Bitwarden repositories. Use when creating PRs, writing PR descriptions, or preparing branches for review. Triggered by "create PR", "pull request", "open PR", "gh pr create", "PR description".
+---
+
+# Create Pull Request
+
+## PR Title Format
+
+```
+[PM-XXXXX] <type>: <short imperative summary>
+```
+
+**Type keywords** (triggers automatic `t:` label via CI):
+
+| Type           | Label               | Use for                                    |
+| -------------- | ------------------- | ------------------------------------------ |
+| `feat`         | `t:feature`         | New features or functionality              |
+| `fix`          | `t:bug`             | Bug fixes                                  |
+| `refactor`     | `t:tech-debt`       | Code restructuring without behavior change |
+| `chore`        | `t:tech-debt`       | Maintenance, cleanup, minor tweaks         |
+| `test`         | `t:tech-debt`       | Adding or updating tests                   |
+| `perf`         | `t:tech-debt`       | Performance improvements                   |
+| `docs`         | `t:docs`            | Documentation changes                      |
+| `ci` / `build` | `t:ci`              | CI/CD and build system changes             |
+| `deps`         | `t:deps`            | Dependency updates                         |
+| `llm`          | `t:llm`             | LLM/Claude configuration changes           |
+| `breaking`     | `t:breaking-change` | Breaking changes requiring migration       |
+| `misc`         | `t:misc`            | Changes that do not fit other categories   |
+
+**Examples:**
+
+- `[PM-12345] feat: Add autofill support for passkeys`
+- `[PM-12345] fix: Resolve crash during vault sync`
+- `[PM-12345] refactor: Simplify authentication flow`
+
+---
+
+## PR Body
+
+**Always follow the repo's PR template at `.github/PULL_REQUEST_TEMPLATE.md`.** Read it and fill in each section. If no template exists, use this fallback:
+
+```markdown
+## 🎟️ Tracking
+
+<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
+
+## 📔 Objective
+
+<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
+
+## 📸 Screenshots
+
+<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
+```
+
+Delete the Screenshots section entirely if there are no UI changes.
+
+---
+
+## Creating the PR
+
+Before creating, run `perform-preflight` if not already done.
+
+```bash
+git push -u origin <branch-name>
+gh pr create --draft --title "[PM-XXXXX] feat: Short summary" --body "<fill in from PR template>"
+```
+
+**Default to draft PRs.** Only create a non-draft PR if the user explicitly requests it.
+
+---
+
+## AI Review Label
+
+Before running `gh pr create`, **always** use the `AskUserQuestion` tool to ask whether to add an AI review label:
+
+- **Question**: "Would you like to add an AI review label to this PR?"
+- **Options**: `ai-review-vnext`, `ai-review`, `No label`
+
+If the user selects a label, include it via the `--label` flag:
+
+```bash
+gh pr create --draft --label "ai-review-vnext" --title "..." --body "..."
+```

--- a/plugins/bitwarden-delivery-tools/skills/creating-pull-request/SKILL.md
+++ b/plugins/bitwarden-delivery-tools/skills/creating-pull-request/SKILL.md
@@ -11,7 +11,7 @@ description: Pull request creation workflow for Bitwarden repositories. Use when
 [PM-XXXXX] <type>: <short imperative summary>
 ```
 
-**Type keywords** (triggers automatic `t:` label via CI): see [Change Type Labels](../../references/change-type-labels.md) for the full table.
+**Type keywords** (triggers automatic `t:` label via CI): read `${CLAUDE_PLUGIN_ROOT}/references/change-type-labels.md` for the full table.
 
 **Examples:**
 

--- a/plugins/bitwarden-delivery-tools/skills/labeling-changes/SKILL.md
+++ b/plugins/bitwarden-delivery-tools/skills/labeling-changes/SKILL.md
@@ -17,6 +17,6 @@ The type keyword appears after the Jira ticket prefix:
 
 ## Type Keywords and Selection Guidance
 
-See [Change Type Labels](../../references/change-type-labels.md) for the full table of type keywords, their CI label mappings, and guidance for selecting a type (including ambiguous cases).
+Read `${CLAUDE_PLUGIN_ROOT}/references/change-type-labels.md` for the full table of type keywords, their CI label mappings, and guidance for selecting a type (including ambiguous cases).
 
 The CI labeling script matches `<type>:` or `<type>(` in the lowercased PR title, so the keyword must be followed by a colon or parenthesis. **If the type cannot be confidently determined, ask the user.**

--- a/plugins/bitwarden-delivery-tools/skills/labeling-changes/SKILL.md
+++ b/plugins/bitwarden-delivery-tools/skills/labeling-changes/SKILL.md
@@ -15,35 +15,8 @@ The type keyword appears after the Jira ticket prefix:
 [PM-XXXXX] <type>: <imperative summary>
 ```
 
-## Type Keywords
+## Type Keywords and Selection Guidance
 
-| Type           | Label               | Use for                                    |
-| -------------- | ------------------- | ------------------------------------------ |
-| `feat`         | `t:feature`         | New features or functionality              |
-| `fix`          | `t:bug`             | Bug fixes                                  |
-| `refactor`     | `t:tech-debt`       | Code restructuring without behavior change |
-| `chore`        | `t:tech-debt`       | Maintenance, cleanup, minor tweaks         |
-| `test`         | `t:tech-debt`       | Adding or updating tests                   |
-| `perf`         | `t:tech-debt`       | Performance improvements                   |
-| `docs`         | `t:docs`            | Documentation changes                      |
-| `ci` / `build` | `t:ci`              | CI/CD and build system changes             |
-| `deps`         | `t:deps`            | Dependency updates                         |
-| `llm`          | `t:llm`             | LLM/Claude configuration changes           |
-| `breaking`     | `t:breaking-change` | Breaking changes requiring migration       |
-| `misc`         | `t:misc`            | Changes that do not fit other categories   |
+See [Change Type Labels](../../references/change-type-labels.md) for the full table of type keywords, their CI label mappings, and guidance for selecting a type (including ambiguous cases).
 
-## Selecting a Type
-
-Infer the type from the task description and changes made. **If the type cannot be confidently determined, ask the user.**
-
-The CI labeling script matches `<type>:` or `<type>(` in the lowercased PR title, so the keyword must be followed by a colon or parenthesis. CI also accepts additional aliases (e.g., `revert`, `bugfix`, `cleanup`). See `.github/label-pr.json` for the full mapping.
-
-### Examples
-
-Ambiguous cases where type selection is non-obvious:
-
-- Refactor that incidentally fixes a bug → use the **primary intent**: `fix:` if the bug was the goal, `refactor:` if the restructuring was the goal
-- Adding tests for existing untested code → `test:` (not `chore:`)
-- Updating a dependency to fix a vulnerability → `deps:` (not `fix:`)
-- Changing Claude/LLM configuration files → `llm:` (not `chore:`)
-- Removing dead code → `refactor:` (not `chore:` — it changes the codebase structure)
+The CI labeling script matches `<type>:` or `<type>(` in the lowercased PR title, so the keyword must be followed by a colon or parenthesis. **If the type cannot be confidently determined, ask the user.**

--- a/plugins/bitwarden-delivery-tools/skills/labeling-changes/SKILL.md
+++ b/plugins/bitwarden-delivery-tools/skills/labeling-changes/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: labeling-changes
+description: Conventional commit type keywords for PR titles and commit messages. Use when determining the change type for commits or PRs. Triggered by "what type", "label", "change type", "conventional commit", "t: label".
+---
+
+# Labeling Changes
+
+PR titles and commit messages must include a conventional commit type keyword. This keyword drives automatic `t:` label assignment via CI (`.github/scripts/label-pr.py` reads `.github/label-pr.json`).
+
+## Format
+
+The type keyword appears after the Jira ticket prefix:
+
+```
+[PM-XXXXX] <type>: <imperative summary>
+```
+
+## Type Keywords
+
+| Type           | Label               | Use for                                    |
+| -------------- | ------------------- | ------------------------------------------ |
+| `feat`         | `t:feature`         | New features or functionality              |
+| `fix`          | `t:bug`             | Bug fixes                                  |
+| `refactor`     | `t:tech-debt`       | Code restructuring without behavior change |
+| `chore`        | `t:tech-debt`       | Maintenance, cleanup, minor tweaks         |
+| `test`         | `t:tech-debt`       | Adding or updating tests                   |
+| `perf`         | `t:tech-debt`       | Performance improvements                   |
+| `docs`         | `t:docs`            | Documentation changes                      |
+| `ci` / `build` | `t:ci`              | CI/CD and build system changes             |
+| `deps`         | `t:deps`            | Dependency updates                         |
+| `llm`          | `t:llm`             | LLM/Claude configuration changes           |
+| `breaking`     | `t:breaking-change` | Breaking changes requiring migration       |
+| `misc`         | `t:misc`            | Changes that do not fit other categories   |
+
+## Selecting a Type
+
+Infer the type from the task description and changes made. **If the type cannot be confidently determined, ask the user.**
+
+The CI labeling script matches `<type>:` or `<type>(` in the lowercased PR title, so the keyword must be followed by a colon or parenthesis. CI also accepts additional aliases (e.g., `revert`, `bugfix`, `cleanup`). See `.github/label-pr.json` for the full mapping.
+
+### Examples
+
+Ambiguous cases where type selection is non-obvious:
+
+- Refactor that incidentally fixes a bug → use the **primary intent**: `fix:` if the bug was the goal, `refactor:` if the restructuring was the goal
+- Adding tests for existing untested code → `test:` (not `chore:`)
+- Updating a dependency to fix a vulnerability → `deps:` (not `fix:`)
+- Changing Claude/LLM configuration files → `llm:` (not `chore:`)
+- Removing dead code → `refactor:` (not `chore:` — it changes the codebase structure)

--- a/plugins/bitwarden-delivery-tools/skills/perform-preflight/SKILL.md
+++ b/plugins/bitwarden-delivery-tools/skills/perform-preflight/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: perform-preflight
+description: Quality gate checklist to run before committing or creating a PR. Use when finishing implementation, checking work quality, or preparing to commit. Triggered by "preflight", "self review", "ready to commit", "check my work", "quality gate".
+---
+
+# Preflight Checklist
+
+Run this checklist before committing or creating a PR. Consult the repo's CLAUDE.md for platform-specific commands (test runner, linter, formatter).
+
+## Tests
+
+- [ ] Run tests for affected modules (consult CLAUDE.md for commands)
+- [ ] New code has test coverage
+- [ ] No existing tests broken
+
+## Code Quality
+
+- [ ] Lint and format pass (consult CLAUDE.md for commands)
+- [ ] No TODO comments without Jira ticket references
+- [ ] Public APIs documented per repo convention (KDoc, DocC, XML docs, etc.)
+
+## Bitwarden Security
+
+- [ ] Zero-knowledge architecture preserved — no unencrypted vault data logged, persisted, or transmitted
+- [ ] Sensitive data uses platform-appropriate secure storage (consult CLAUDE.md Security Rules)
+- [ ] No sensitive data in log statements
+
+## Architecture
+
+- [ ] Changes follow patterns in CLAUDE.md and architecture docs
+- [ ] DI/injection and error handling follow repo convention
+- [ ] String resources added to the correct location (if applicable)
+
+## On Failure
+
+If any check fails, fix the issue before proceeding. For test failures, diagnose the root cause rather than skipping. For lint/format failures, run the repo's auto-fix command if available. If a check cannot be resolved, flag it to the user with the specific failure output.

--- a/plugins/bitwarden-delivery-tools/skills/perform-preflight/SKILL.md
+++ b/plugins/bitwarden-delivery-tools/skills/perform-preflight/SKILL.md
@@ -28,7 +28,7 @@ Run this checklist before committing or creating a PR. Consult the repo's CLAUDE
 ## Architecture
 
 - [ ] Changes follow patterns in CLAUDE.md and architecture docs
-- [ ] DI/injection and error handling follow repo convention
+- [ ] Dependency injection and error handling follow repo convention
 - [ ] String resources added to the correct location (if applicable)
 
 ## On Failure


### PR DESCRIPTION
## 🎟️ Tracking

PM-35361

## 📔 Objective

Introduce a generic delivery-tools plugin (`committing-changes`, `creating-pull-request`,
`labeling-changes`, `perform-preflight`) for use across any Bitwarden repository.
