### PR TITLE
Allow read-only gh and git in code-review-local command

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -25,7 +25,7 @@
     {
       "name": "bitwarden-code-review",
       "source": "./plugins/bitwarden-code-review",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "description": "Comprehensive code review system with organization-wide standards."
     },
     {

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A curated collection of plugins for AI-assisted development at Bitwarden. Enable
 | ------------------------------------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------- |
 | [bitwarden-architect](plugins/bitwarden-architect/)                 | 1.0.0   | Software architect for technical planning, architecture reviews, and implementation phasing                         |
 | [bitwarden-atlassian-tools](plugins/bitwarden-atlassian-tools/)     | 2.2.3   | Read-only Atlassian access via MCP server with deep Jira issue research skill                                       |
-| [bitwarden-code-review](plugins/bitwarden-code-review/)             | 1.9.0   | Autonomous code review agent following Bitwarden engineering standards with GitHub integration                      |
+| [bitwarden-code-review](plugins/bitwarden-code-review/)             | 1.9.1   | Autonomous code review agent following Bitwarden engineering standards with GitHub integration                      |
 | [bitwarden-devops-engineer](plugins/bitwarden-devops-engineer/)     | 0.1.1   | DevOps engineering assistant: workflow compliance linting, action security auditing, and org-wide CI/CD remediation |
 | [bitwarden-init](plugins/bitwarden-init/)                           | 1.1.0   | Initialize and enhance CLAUDE.md files with Bitwarden's standardized template format                                |
 | [bitwarden-product-analyst](plugins/bitwarden-product-analyst/)     | 0.1.5   | Product analyst agent for creating comprehensive Bitwarden requirements documents from multiple sources             |

--- a/plugins/bitwarden-code-review/.claude-plugin/plugin.json
+++ b/plugins/bitwarden-code-review/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bitwarden-code-review",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Comprehensive code review system with organization-wide standards.",
   "author": {
     "name": "Bitwarden",

--- a/plugins/bitwarden-code-review/CHANGELOG.md
+++ b/plugins/bitwarden-code-review/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the Bitwarden Code Review Plugin will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.1] - 2026-04-27
+
+### Changed
+
+- `code-review-local` command now declares `allowed-tools` in its frontmatter, mirroring `code-review`, so the read-only `gh` and `git` patterns it relies on are pre-authorized for the duration of the command and don't prompt on every invocation
+- `Write` access in `code-review-local` is scoped to the two output files (`review-summary.md`, `review-inline-comments.md`) rather than granted broadly
+
 ## [1.9.0] - 2026-04-06
 
 ### Added

--- a/plugins/bitwarden-code-review/agents/bitwarden-code-reviewer/AGENT.md
+++ b/plugins/bitwarden-code-review/agents/bitwarden-code-reviewer/AGENT.md
@@ -1,6 +1,6 @@
 ---
 name: bitwarden-code-reviewer
-version: 1.9.0
+version: 1.9.1
 description: Conducts thorough code reviews following Bitwarden standards. Finds all issues first pass, avoids false positives, respects codebase conventions. Invoke when user mentions "code review", "review code", "review", "PR", or "pull request".
 model: opus
 skills: avoiding-false-positives, classifying-review-findings, posting-bitwarden-review-comments, posting-review-summary, reviewing-dependency-changes

--- a/plugins/bitwarden-code-review/commands/code-review-local/code-review-local.md
+++ b/plugins/bitwarden-code-review/commands/code-review-local/code-review-local.md
@@ -1,5 +1,6 @@
 ---
 argument-hint: [PR#] | [PR URL]
+allowed-tools: Read, Write(review-summary.md), Write(review-inline-comments.md), Bash(gh pr view:*), Bash(gh pr diff:*), Bash(gh pr checks:*), Bash(git show:*), Bash(gh pr list:*), Bash(git log:*), Bash(git diff:*), "Bash(gh api graphql -f query=:*)", Grep, Glob, Task, Skill
 description: Review a GitHub pull request or local changes and write the review to local files instead of posting
 ---
 


### PR DESCRIPTION
## 🎟️ Tracking

N/A — internal plugin polish.

## 📔 Objective

Bumps `bitwarden-code-review` to **1.9.1**.

The `/bitwarden-code-review:code-review-local` command currently has no `allowed-tools` frontmatter, so every invocation prompts for permission on the read-only `gh` and `git` calls it needs to fetch PR metadata, diff, and existing review threads. This PR mirrors what `code-review` already declares so those calls are pre-authorized for the duration of the command:

- Adds `allowed-tools` to the `code-review-local` command frontmatter covering the read-only `gh pr view`, `gh pr diff`, `gh pr checks`, `gh pr list`, `gh api graphql`, `git show`, `git log`, `git diff` patterns the command actually uses.
- Scopes `Write` to the two output files (`review-summary.md`, `review-inline-comments.md`) rather than granting it broadly — keeps the command focused on its documented output and prevents incidental writes elsewhere.
- No behavioral change to the review itself; this only removes per-invocation prompting friction.