### PR TITLE
Add Skill tool to software-engineer and security-engineer agents

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -43,7 +43,7 @@
     {
       "name": "bitwarden-software-engineer",
       "source": "./plugins/bitwarden-software-engineer",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "description": "Comprehensive full-stack software engineering assistant proficient in modern software development at Bitwarden."
     },
     {
@@ -55,7 +55,7 @@
     {
       "name": "bitwarden-security-engineer",
       "source": "./plugins/bitwarden-security-engineer",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "description": "Application security engineering assistant for vulnerability triage, threat modeling, and secure code analysis."
     },
     {

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ A curated collection of plugins for AI-assisted development at Bitwarden. Enable
 | [bitwarden-devops-engineer](plugins/bitwarden-devops-engineer/)     | 0.1.1   | DevOps engineering assistant: workflow compliance linting, action security auditing, and org-wide CI/CD remediation |
 | [bitwarden-init](plugins/bitwarden-init/)                           | 1.1.0   | Initialize and enhance CLAUDE.md files with Bitwarden's standardized template format                                |
 | [bitwarden-product-analyst](plugins/bitwarden-product-analyst/)     | 0.1.5   | Product analyst agent for creating comprehensive Bitwarden requirements documents from multiple sources             |
-| [bitwarden-security-engineer](plugins/bitwarden-security-engineer/) | 1.1.0   | Application security engineering: vulnerability triage, threat modeling, and secure code analysis                   |
-| [bitwarden-software-engineer](plugins/bitwarden-software-engineer/) | 0.4.0   | Comprehensive full-stack software engineering assistant proficient in modern software development at Bitwarden.     |
+| [bitwarden-security-engineer](plugins/bitwarden-security-engineer/) | 1.1.1 | Application security engineering: vulnerability triage, threat modeling, and secure code analysis                   |
+| [bitwarden-software-engineer](plugins/bitwarden-software-engineer/) | 0.4.1 | Comprehensive full-stack software engineering assistant proficient in modern software development at Bitwarden.     |
 | [claude-config-validator](plugins/claude-config-validator/)         | 1.1.1   | Validates Claude Code configuration files for security, structure, and quality                                      |
 | [claude-retrospective](plugins/claude-retrospective/)               | 1.1.1   | Analyze Claude Code sessions to identify successful patterns and improvement opportunities                          |
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ A curated collection of plugins for AI-assisted development at Bitwarden. Enable
 | [bitwarden-devops-engineer](plugins/bitwarden-devops-engineer/)     | 0.1.1   | DevOps engineering assistant: workflow compliance linting, action security auditing, and org-wide CI/CD remediation |
 | [bitwarden-init](plugins/bitwarden-init/)                           | 1.1.0   | Initialize and enhance CLAUDE.md files with Bitwarden's standardized template format                                |
 | [bitwarden-product-analyst](plugins/bitwarden-product-analyst/)     | 0.1.5   | Product analyst agent for creating comprehensive Bitwarden requirements documents from multiple sources             |
-| [bitwarden-security-engineer](plugins/bitwarden-security-engineer/) | 1.1.1 | Application security engineering: vulnerability triage, threat modeling, and secure code analysis                   |
-| [bitwarden-software-engineer](plugins/bitwarden-software-engineer/) | 0.4.1 | Comprehensive full-stack software engineering assistant proficient in modern software development at Bitwarden.     |
+| [bitwarden-security-engineer](plugins/bitwarden-security-engineer/) | 1.1.1   | Application security engineering: vulnerability triage, threat modeling, and secure code analysis                   |
+| [bitwarden-software-engineer](plugins/bitwarden-software-engineer/) | 0.4.1   | Comprehensive full-stack software engineering assistant proficient in modern software development at Bitwarden.     |
 | [claude-config-validator](plugins/claude-config-validator/)         | 1.1.1   | Validates Claude Code configuration files for security, structure, and quality                                      |
 | [claude-retrospective](plugins/claude-retrospective/)               | 1.1.1   | Analyze Claude Code sessions to identify successful patterns and improvement opportunities                          |
 

--- a/plugins/bitwarden-security-engineer/.claude-plugin/plugin.json
+++ b/plugins/bitwarden-security-engineer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bitwarden-security-engineer",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Application security engineering assistant for vulnerability triage, threat modeling, and secure code analysis at Bitwarden.",
   "author": {
     "name": "Bitwarden",
@@ -15,5 +15,7 @@
     "threat-modeling",
     "security-review"
   ],
-  "agents": ["./agents/bitwarden-security-engineer.md"]
+  "agents": [
+    "./agents/bitwarden-security-engineer.md"
+  ]
 }

--- a/plugins/bitwarden-security-engineer/.claude-plugin/plugin.json
+++ b/plugins/bitwarden-security-engineer/.claude-plugin/plugin.json
@@ -15,7 +15,5 @@
     "threat-modeling",
     "security-review"
   ],
-  "agents": [
-    "./agents/bitwarden-security-engineer.md"
-  ]
+  "agents": ["./agents/bitwarden-security-engineer.md"]
 }

--- a/plugins/bitwarden-security-engineer/CHANGELOG.md
+++ b/plugins/bitwarden-security-engineer/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the `bitwarden-security-engineer` plugin will be document
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2026-05-07
+
+### Fixed
+
+- Added `Skill` to the agent's `tools:` frontmatter so the agent can dispatch the six skills declared in its `skills:` block (`triaging-security-findings`, `threat-modeling`, `analyzing-code-security`, `reviewing-dependencies`, `detecting-secrets`, `reviewing-security-architecture`). Previously these declared skills could not be invoked.
+
 ## [1.1.0] - 2026-05-05
 
 ### Changed

--- a/plugins/bitwarden-security-engineer/agents/bitwarden-security-engineer.md
+++ b/plugins/bitwarden-security-engineer/agents/bitwarden-security-engineer.md
@@ -2,7 +2,7 @@
 name: bitwarden-security-engineer
 description: Application security engineer specializing in vulnerability triage, threat modeling, and secure code analysis. Use for security findings remediation, threat model generation, dependency audits, and architecture security review.
 model: opus
-tools: Read, Write, Edit, Bash, Glob, Grep
+tools: Read, Write, Edit, Bash, Glob, Grep, Skill
 skills:
   - triaging-security-findings
   - threat-modeling

--- a/plugins/bitwarden-software-engineer/.claude-plugin/plugin.json
+++ b/plugins/bitwarden-software-engineer/.claude-plugin/plugin.json
@@ -8,13 +8,6 @@
   },
   "homepage": "https://github.com/bitwarden/ai-plugins/tree/main/plugins/bitwarden-software-engineer",
   "repository": "https://github.com/bitwarden/ai-plugins",
-  "keywords": [
-    "typescript",
-    "csharp",
-    "sql",
-    "fullstack"
-  ],
-  "agents": [
-    "./agents/bitwarden-software-engineer.md"
-  ]
+  "keywords": ["typescript", "csharp", "sql", "fullstack"],
+  "agents": ["./agents/bitwarden-software-engineer.md"]
 }

--- a/plugins/bitwarden-software-engineer/.claude-plugin/plugin.json
+++ b/plugins/bitwarden-software-engineer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bitwarden-software-engineer",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Comprehensive full-stack software engineering assistant proficient in modern software development at Bitwarden.",
   "author": {
     "name": "Bitwarden",
@@ -8,6 +8,13 @@
   },
   "homepage": "https://github.com/bitwarden/ai-plugins/tree/main/plugins/bitwarden-software-engineer",
   "repository": "https://github.com/bitwarden/ai-plugins",
-  "keywords": ["typescript", "csharp", "sql", "fullstack"],
-  "agents": ["./agents/bitwarden-software-engineer.md"]
+  "keywords": [
+    "typescript",
+    "csharp",
+    "sql",
+    "fullstack"
+  ],
+  "agents": [
+    "./agents/bitwarden-software-engineer.md"
+  ]
 }

--- a/plugins/bitwarden-software-engineer/CHANGELOG.md
+++ b/plugins/bitwarden-software-engineer/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the `bitwarden-software-engineer` plugin will be document
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2026-05-07
+
+### Fixed
+
+- Added `Skill` to the agent's `tools:` frontmatter. Without it, the agent could not invoke Claude Code skills, so slash-command and skill-based workflows silently failed to dispatch.
+
 ## [0.4.0] - 2026-04-21
 
 ### Changed

--- a/plugins/bitwarden-software-engineer/agents/bitwarden-software-engineer.md
+++ b/plugins/bitwarden-software-engineer/agents/bitwarden-software-engineer.md
@@ -2,7 +2,7 @@
 name: bitwarden-software-engineer
 description: Comprehensive full-stack software engineering assistant proficient in modern software development at Bitwarden. Use for feature implementation, and cross-language refactoring.
 model: opus
-tools: Read, Write, Edit, Bash, Glob, Grep
+tools: Read, Write, Edit, Bash, Glob, Grep, Skill
 color: blue
 ---
 


### PR DESCRIPTION
## 🎟️ Tracking

No Jira ticket — defect found and triaged in-session. The agent definitions advertised capabilities they could not actually dispatch.

## 📔 Objective

Add `Skill` to the `tools:` frontmatter of two subagents that were missing it, so they can invoke Claude Code skills via the `Skill` tool.

| Plugin | Version | Notes |
|---|---|---|
| `bitwarden-software-engineer` | 0.4.0 → **0.4.1** | Could not invoke skills via slash-command or skill-based workflows. |
| `bitwarden-security-engineer` | 1.1.0 → **1.1.1** | Declared six skills in its `skills:` frontmatter block (`triaging-security-findings`, `threat-modeling`, `analyzing-code-security`, `reviewing-dependencies`, `detecting-secrets`, `reviewing-security-architecture`) but had no way to dispatch any of them at runtime. |

The same failure mode was empirically confirmed for `bitwarden-software-engineer` in a prior session.

### What this PR changes

- One-line edit to each agent's `tools:` frontmatter (appending `, Skill`).
- PATCH-level version bumps via `./scripts/bump-plugin-version.sh` per the repo's `CLAUDE.md` "Modifying Existing Plugins" convention. This auto-updates `.claude-plugin/marketplace.json`, each plugin's `.claude-plugin/plugin.json`, and the `README.md` catalog table.
- New `### Fixed` entries in each plugin's `CHANGELOG.md` (Keep a Changelog format).

### Side-effect to flag

The bump script reformatted both `plugin.json` files' inline `keywords` and `agents` arrays to multi-line. This aligns the two manifests with the dominant repo style (9 of 11 plugins already use multi-line arrays); not a stylistic regression.

### Validation

Both pass cleanly:

- `./scripts/validate-plugin-structure.sh bitwarden-software-engineer` ✅
- `./scripts/validate-plugin-structure.sh bitwarden-security-engineer` ✅
- `./scripts/validate-marketplace.sh bitwarden-software-engineer` ✅
- `./scripts/validate-marketplace.sh bitwarden-security-engineer` ✅

## 📸 Screenshots

N/A — no UI surface affected.