### PR TITLE
fix: Add explicit GitHub endpoint guidance to addressing-code-review-comments skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -25,7 +25,7 @@
     {
       "name": "bitwarden-code-review",
       "source": "./plugins/bitwarden-code-review",
-      "version": "1.10.0",
+      "version": "1.10.1",
       "description": "Comprehensive code review system with organization-wide standards."
     },
     {

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A curated collection of plugins for AI-assisted development at Bitwarden. Enable
 | ------------------------------------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------- |
 | [bitwarden-tech-lead](plugins/bitwarden-tech-lead/)                 | 2.1.0   | Tech lead for technical planning, architecture coherence, and surfacing patterns to Technical Strategy Ideas        |
 | [bitwarden-atlassian-tools](plugins/bitwarden-atlassian-tools/)     | 2.2.3   | Read-only Atlassian access via MCP server with deep Jira issue research skill                                       |
-| [bitwarden-code-review](plugins/bitwarden-code-review/)             | 1.10.0  | Autonomous code review agent following Bitwarden engineering standards with GitHub integration                      |
+| [bitwarden-code-review](plugins/bitwarden-code-review/)             | 1.10.1  | Autonomous code review agent following Bitwarden engineering standards with GitHub integration                      |
 | [bitwarden-delivery-tools](plugins/bitwarden-delivery-tools/)       | 1.1.0   | Delivery lifecycle skills: initiative funnel navigation, work transitions, commits, PRs, preflight checks, labeling |
 | [bitwarden-devops-engineer](plugins/bitwarden-devops-engineer/)     | 0.1.1   | DevOps engineering assistant: workflow compliance linting, action security auditing, and org-wide CI/CD remediation |
 | [bitwarden-init](plugins/bitwarden-init/)                           | 1.1.0   | Initialize and enhance CLAUDE.md files with Bitwarden's standardized template format                                |

--- a/plugins/bitwarden-code-review/.claude-plugin/plugin.json
+++ b/plugins/bitwarden-code-review/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bitwarden-code-review",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Comprehensive code review system with organization-wide standards.",
   "author": {
     "name": "Bitwarden",

--- a/plugins/bitwarden-code-review/CHANGELOG.md
+++ b/plugins/bitwarden-code-review/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Bitwarden Code Review Plugin will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.10.1] - 2026-05-12
+
+### Changed
+
+- `addressing-code-review-comments` skill now explicitly instructs fetching PR feedback from all three GitHub endpoints (`/pulls/{n}/comments` for inline, `/pulls/{n}/reviews` for review summaries, `/issues/{n}/comments` for top-level conversation comments). Previously the skill said "read the full set of comments" without naming the endpoints, which let the model silently miss conversation comments that live only at `/issues/`
+
 ## [1.10.0] - 2026-04-28
 
 ### Added

--- a/plugins/bitwarden-code-review/agents/bitwarden-code-reviewer/AGENT.md
+++ b/plugins/bitwarden-code-review/agents/bitwarden-code-reviewer/AGENT.md
@@ -1,6 +1,6 @@
 ---
 name: bitwarden-code-reviewer
-version: 1.10.0
+version: 1.10.1
 description: Conducts thorough code reviews following Bitwarden standards. Finds all issues first pass, avoids false positives, respects codebase conventions. Invoke when user mentions "code review", "review code", "review", "PR", or "pull request".
 model: opus
 skills: avoiding-false-positives, classifying-review-findings, posting-bitwarden-review-comments, posting-review-summary, reviewing-dependency-changes

--- a/plugins/bitwarden-code-review/skills/addressing-code-review-comments/SKILL.md
+++ b/plugins/bitwarden-code-review/skills/addressing-code-review-comments/SKILL.md
@@ -22,6 +22,16 @@ For each review:
 
 If a comment is unclear, stop and ask the user before touching anything. Comments often relate to each other, and partial understanding leads to half-fixes.
 
+## Fetching the Full Set of Comments
+
+PR feedback lives across three separate GitHub API endpoints. Call all three:
+
+- **Inline review comments** — line-level, attached to a diff hunk: `repos/{owner}/{repo}/pulls/{pr}/comments`
+- **Reviews** — the summary message a reviewer leaves when they submit their review: `repos/{owner}/{repo}/pulls/{pr}/reviews`
+- **Conversation comments** — top-level PR comments not attached to any line, posted in the main conversation thread: `repos/{owner}/{repo}/issues/{pr}/comments` (note: `issues`, not `pulls` — PRs are issues underneath)
+
+If the user says you missed a comment, check coverage of all three endpoints before re-reading the data you already fetched — the gap may be that you missed an endpoint.
+
 ## Evaluating a Suggestion
 
 Before recommending the user implement, check:


### PR DESCRIPTION
## 🎟️ Tracking

Internal change, let me know if it needs a ticket.

## 📔 Objective

During use, the `addressing-code-review-comments` skill missed certain types of comments (in this case, review summary bodies). It required some prompting to actually go back and look for more comments.

The fix is to add a "Fetching the Full Set of Comments" section to the skill that names all three GitHub PR comment endpoints explicitly:

- `/pulls/{n}/comments` — inline review comments (line-level)
- `/pulls/{n}/reviews` — review summary bodies
- `/issues/{n}/comments` — top-level conversation comments (PRs are issues underneath)

Also adds a meta-instruction: if the user reports a missed comment, check endpoint coverage before re-reading already-fetched data.

Bumps `bitwarden-code-review` to 1.10.1 (PATCH — documentation update to existing skill).

### Validation

I ran tests against some PRs - they couldn't recreate the original issue so it's unclear whether this issue will reoccur in practice, but I think it's worthwhile adding explicit instructions to make sure.