### PR TITLE
ci: post Claude validation results as a sticky PR comment

### DIFF
--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -185,8 +185,8 @@ jobs:
 
             # RULES
 
-            1. The repository is already checked out at the PR head with full git history.
-            2. You can read files directly and use git commands to inspect changes.
+            1. The repository is already checked out at the PR head.
+            2. You can read files directly to inspect the changed plugin components.
             3. When your validation is complete, write your final report in markdown
                format to /tmp/validation-summary.md. This file will be used to update
                the sticky PR comment automatically. Do not attempt to post PR comments

--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -174,7 +174,7 @@ jobs:
           claude_args: |
             --verbose
             --model opus
-            --allowedTools "Task,Skill,Read,Write,Grep,Glob,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(ls:*),Bash(find:*),Bash(cat:*)"
+            --allowedTools "Task,Skill,Read,Write,Grep,Glob"
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -144,6 +144,20 @@ jobs:
         if: steps.changed-files.outputs.has_components == 'true'
         uses: bitwarden/gh-actions/azure-logout@main
 
+      - name: Create PR comment placeholder
+        id: create-comment
+        if: steps.changed-files.outputs.has_components == 'true'
+        uses: bitwarden/gh-actions/update-pr-comment@main
+        with:
+          token: ${{ github.token }}
+          pr_number: ${{ github.event.pull_request.number }}
+          repository: ${{ github.repository }}
+          marker_id: bitwarden-plugin-validation
+          body: |
+            **Claude Code** is validating plugin components and security...
+
+            If this comment does not update with results, check the [Actions log](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).
+
       - name: Validate plugin components and security
         id: components
         if: steps.changed-files.outputs.has_components == 'true'
@@ -157,9 +171,26 @@ jobs:
           plugins: |
             plugin-dev@claude-code-plugins
             claude-config-validator@bitwarden-marketplace
+          claude_args: |
+            --verbose
+            --model opus
+            --allowedTools "Task,Skill,Read,Write,Grep,Glob,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(ls:*),Bash(find:*),Bash(cat:*)"
           prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+            STICKY COMMENT ID: ${{ steps.create-comment.outputs.comment_id }}
+
             You have access to two plugins: plugin-dev and claude-config-validator.
             Use their specialized agents to validate the changed plugin files below.
+
+            # RULES
+
+            1. The repository is already checked out at the PR head with full git history.
+            2. You can read files directly and use git commands to inspect changes.
+            3. When your validation is complete, write your final report in markdown
+               format to /tmp/validation-summary.md. This file will be used to update
+               the sticky PR comment automatically. Do not attempt to post PR comments
+               yourself.
 
             Changed files:
             ${{ steps.changed-files.outputs.changed_files }}
@@ -218,12 +249,27 @@ jobs:
 
             ## Output Requirements
 
-            Combine all findings into a single structured report:
+            Write your final report to /tmp/validation-summary.md as a single
+            structured markdown document:
             - Categorize issues by severity: critical, major, minor
             - Include the exact file path and line for each issue
             - Provide specific remediation guidance for each violation
             - Distinguish errors (must fix) from warnings (should fix)
             - If all checks pass, confirm with a summary of what was validated
+
+            The report must be written to /tmp/validation-summary.md even when
+            all checks pass — the sticky PR comment is replaced with its contents.
+
+      - name: Update PR comment with validation summary
+        if: always() && steps.changed-files.outputs.has_components == 'true' && steps.create-comment.outputs.comment_id != ''
+        uses: bitwarden/gh-actions/update-pr-comment@main
+        with:
+          token: ${{ github.token }}
+          pr_number: ${{ github.event.pull_request.number }}
+          repository: ${{ github.repository }}
+          marker_id: bitwarden-plugin-validation
+          comment_id: ${{ steps.create-comment.outputs.comment_id }}
+          body_file: /tmp/validation-summary.md
 
       - name: Summary
         if: always()


### PR DESCRIPTION
## Summary

The Claude-driven plugin validation step in `validate-plugins.yml` runs successfully but never delivers its findings to the PR. The `anthropics/claude-code-action` only posts comments via `post-buffered-inline-comments.ts`, which logs `No buffered inline comments` and exits — the markdown report Claude produces is discarded.

See run [25758816161](https://github.com/bitwarden/ai-plugins/actions/runs/25758816161/job/75654322288?pr=116) for the symptom (`subtype: success`, no PR comment posted, `permission_denials_count: 7`).

This PR adopts the standard pattern from [`bitwarden/gh-actions/run-code-review`](https://github.com/bitwarden/gh-actions/blob/main/run-code-review/action.yml):

- **Pre-step**: `bitwarden/gh-actions/update-pr-comment` creates a sticky placeholder (`marker_id: bitwarden-plugin-validation`) so PR authors see an in-progress indicator immediately.
- **Claude step**: prompt now instructs Claude to write its final markdown to `/tmp/validation-summary.md`. `claude_args` adds `--model opus`, `--verbose`, and an explicit `--allowedTools` allowlist (`Task`, `Skill`, `Read`, `Write`, `Grep`, `Glob`, read-only `Bash`) so the previous `permission_denials_count: 7` clears.
- **Post-step** (`if: always()`): replaces the placeholder with the file contents via `update-pr-comment`, so the comment lands even when Claude's session fails.

REPO / PR NUMBER / STICKY COMMENT ID context lines are prepended to the prompt to mirror the run-code-review shape.

## Test plan

- [ ] CI's existing structure / marketplace / version-bump steps still pass on this PR (no plugin files changed; the components job should short-circuit on `has_components`).
- [ ] Open a follow-up PR that touches a plugin component (AGENT.md / SKILL.md / hooks.json) and confirm:
  - [ ] Placeholder "Claude Code is validating..." comment appears soon after the workflow starts.
  - [ ] Placeholder is replaced by Claude's validation report once the components step finishes.
  - [ ] Re-running the workflow updates the same comment (does not stack).
  - [ ] On a forced Claude failure, the placeholder remains with its Actions-log link rather than disappearing.
- [ ] Verify `permission_denials_count` in the Claude execution JSON drops toward 0 with the new `--allowedTools` allowlist.