### PR TITLE
ci: detect command file changes in plugin validation

### DIFF
--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -54,13 +54,15 @@ jobs:
           # Extract unique plugin directories from changed files
           CHANGED_PLUGINS=$(echo "$CHANGED_FILES" | cut -d/ -f1-2 | sort -u | tr '\n' ' ' | sed 's/ $//')
 
-          # Filter for AGENT.md, SKILL.md, and hooks.json files
+          # Filter for AGENT.md, SKILL.md, command, and hooks.json files
           # Agent files can be in two patterns:
           #   1. plugins/*/agents/*/AGENT.md (subdirectory with AGENT.md)
           #   2. plugins/*/agents/*.md (direct .md files in agents directory)
           AGENT_FILES=$(echo "$CHANGED_FILES" | grep -E '/agents/.*\.md$' || echo "")
           # Skill files are in plugins/*/skills/*/SKILL.md
           SKILL_FILES=$(echo "$CHANGED_FILES" | grep '/skills/.*/SKILL\.md$' || echo "")
+          # Command files are in plugins/*/commands/*.md or plugins/*/commands/*/*.md
+          COMMAND_FILES=$(echo "$CHANGED_FILES" | grep -E '/commands/.*\.md$' || echo "")
           HOOK_FILES=$(echo "$CHANGED_FILES" | grep 'hooks\.json$' || echo "")
 
           {
@@ -74,13 +76,16 @@ jobs:
             echo "skill_files<<EOF"
             echo "$SKILL_FILES"
             echo "EOF"
+            echo "command_files<<EOF"
+            echo "$COMMAND_FILES"
+            echo "EOF"
             echo "hook_files<<EOF"
             echo "$HOOK_FILES"
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
           # Check if there are any plugin component files to validate
-          if [[ -n "$AGENT_FILES" ]] || [[ -n "$SKILL_FILES" ]] || [[ -n "$HOOK_FILES" ]]; then
+          if [[ -n "$AGENT_FILES" ]] || [[ -n "$SKILL_FILES" ]] || [[ -n "$COMMAND_FILES" ]] || [[ -n "$HOOK_FILES" ]]; then
             echo "has_components=true" >> "$GITHUB_OUTPUT"
           else
             echo "has_components=false" >> "$GITHUB_OUTPUT"
@@ -203,6 +208,9 @@ jobs:
 
             Skill files changed:
             ${{ steps.changed-files.outputs.skill_files }}
+
+            Command files changed:
+            ${{ steps.changed-files.outputs.command_files }}
 
             Hook files changed:
             ${{ steps.changed-files.outputs.hook_files }}


### PR DESCRIPTION
## 🎟️ Tracking

Surfaced during review of [#119](https://github.com/bitwarden/ai-plugins/pull/119). That PR added four new slash commands to the `bitwarden-init` plugin and CI ran [run 25867306399](https://github.com/bitwarden/ai-plugins/actions/runs/25867306399/job/76012745337?pr=119) reporting:

```
Version bump validation: skipped (no component files changed)
Component & security validation (AI-driven): skipped (no component files changed)
```

…even though four command files and a manifest version bump were in the diff.

## 📔 Objective

Fix the change-detection logic in `.github/workflows/validate-plugins.yml` so that command file changes count as component changes.

### Root cause

The workflow's `has_components` flag drives both the version-bump validator and the AI-driven component & security validator. It was computed from three file groups:

```bash
AGENT_FILES=$(echo "$CHANGED_FILES" | grep -E '/agents/.*\.md$' || echo "")
SKILL_FILES=$(echo "$CHANGED_FILES" | grep '/skills/.*/SKILL\.md$' || echo "")
HOOK_FILES=$(echo "$CHANGED_FILES" | grep 'hooks\.json$' || echo "")

if [[ -n "$AGENT_FILES" ]] || [[ -n "$SKILL_FILES" ]] || [[ -n "$HOOK_FILES" ]]; then
  echo "has_components=true" >> "$GITHUB_OUTPUT"
```

Commands aren't in the OR. Any command-only PR — even one that introduces brand-new commands or modifies command frontmatter — bypasses both AI-driven checks, including the version-bump enforcement that the repo CLAUDE.md requires for "ANY substantive changes to a plugin."

### Fix

- Add a `COMMAND_FILES` matcher with the same breadth as `AGENT_FILES`: `grep -E '/commands/.*\.md$'`. This catches both the `commands/<slug>/<slug>.md` and `commands/<slug>.md` patterns seen across the marketplace.
- Add `COMMAND_FILES` to the `has_components` OR alongside the other three.
- Expose `command_files` as a step output, matching the existing `agent_files` / `skill_files` / `hook_files` pattern.
- Surface "Command files changed:" in the AI validator's prompt block alongside the others so the validator can read them.

Minimal change — 10 insertions, 2 deletions. Same shape as existing detectors; no behavior change for PRs that already have agents/skills/hooks.

## ✅ Test plan

- [ ] Confirm a command-only PR (e.g., re-running CI on #119 after this merges, or a follow-up test PR that only touches `plugins/*/commands/`) flips `has_components` to `true` and runs both the version-bump and AI-driven validators
- [ ] Confirm an agent/skill/hook-only PR is unaffected — the previously-passing detection still passes
- [ ] Confirm a no-component PR (e.g., a docs-only change to a plugin's README) still reports `has_components=false`