### PR TITLE
feat(software-engineer-agent): Add format instruction for server.

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -43,7 +43,7 @@
     {
       "name": "bitwarden-software-engineer",
       "source": "./plugins/bitwarden-software-engineer",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "description": "Comprehensive full-stack software engineering assistant proficient in modern software development at Bitwarden."
     },
     {

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A curated collection of plugins for AI-assisted development at Bitwarden. Enable
 | [bitwarden-init](plugins/bitwarden-init/)                           | 1.1.0   | Initialize and enhance CLAUDE.md files with Bitwarden's standardized template format                                |
 | [bitwarden-product-analyst](plugins/bitwarden-product-analyst/)     | 0.1.5   | Product analyst agent for creating comprehensive Bitwarden requirements documents from multiple sources             |
 | [bitwarden-security-engineer](plugins/bitwarden-security-engineer/) | 1.2.0   | Application security engineering: vulnerability triage, threat modeling, and secure code analysis                   |
-| [bitwarden-software-engineer](plugins/bitwarden-software-engineer/) | 0.4.1   | Comprehensive full-stack software engineering assistant proficient in modern software development at Bitwarden.     |
+| [bitwarden-software-engineer](plugins/bitwarden-software-engineer/) | 0.4.2 | Comprehensive full-stack software engineering assistant proficient in modern software development at Bitwarden.     |
 | [claude-config-validator](plugins/claude-config-validator/)         | 1.1.1   | Validates Claude Code configuration files for security, structure, and quality                                      |
 | [claude-retrospective](plugins/claude-retrospective/)               | 1.1.1   | Analyze Claude Code sessions to identify successful patterns and improvement opportunities                          |
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A curated collection of plugins for AI-assisted development at Bitwarden. Enable
 | [bitwarden-init](plugins/bitwarden-init/)                           | 1.1.0   | Initialize and enhance CLAUDE.md files with Bitwarden's standardized template format                                |
 | [bitwarden-product-analyst](plugins/bitwarden-product-analyst/)     | 0.1.5   | Product analyst agent for creating comprehensive Bitwarden requirements documents from multiple sources             |
 | [bitwarden-security-engineer](plugins/bitwarden-security-engineer/) | 1.2.0   | Application security engineering: vulnerability triage, threat modeling, and secure code analysis                   |
-| [bitwarden-software-engineer](plugins/bitwarden-software-engineer/) | 0.4.2 | Comprehensive full-stack software engineering assistant proficient in modern software development at Bitwarden.     |
+| [bitwarden-software-engineer](plugins/bitwarden-software-engineer/) | 0.4.2   | Comprehensive full-stack software engineering assistant proficient in modern software development at Bitwarden.     |
 | [claude-config-validator](plugins/claude-config-validator/)         | 1.1.1   | Validates Claude Code configuration files for security, structure, and quality                                      |
 | [claude-retrospective](plugins/claude-retrospective/)               | 1.1.1   | Analyze Claude Code sessions to identify successful patterns and improvement opportunities                          |
 

--- a/plugins/bitwarden-software-engineer/.claude-plugin/plugin.json
+++ b/plugins/bitwarden-software-engineer/.claude-plugin/plugin.json
@@ -8,13 +8,6 @@
   },
   "homepage": "https://github.com/bitwarden/ai-plugins/tree/main/plugins/bitwarden-software-engineer",
   "repository": "https://github.com/bitwarden/ai-plugins",
-  "keywords": [
-    "typescript",
-    "csharp",
-    "sql",
-    "fullstack"
-  ],
-  "agents": [
-    "./agents/bitwarden-software-engineer.md"
-  ]
+  "keywords": ["typescript", "csharp", "sql", "fullstack"],
+  "agents": ["./agents/bitwarden-software-engineer.md"]
 }

--- a/plugins/bitwarden-software-engineer/.claude-plugin/plugin.json
+++ b/plugins/bitwarden-software-engineer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bitwarden-software-engineer",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Comprehensive full-stack software engineering assistant proficient in modern software development at Bitwarden.",
   "author": {
     "name": "Bitwarden",
@@ -8,6 +8,13 @@
   },
   "homepage": "https://github.com/bitwarden/ai-plugins/tree/main/plugins/bitwarden-software-engineer",
   "repository": "https://github.com/bitwarden/ai-plugins",
-  "keywords": ["typescript", "csharp", "sql", "fullstack"],
-  "agents": ["./agents/bitwarden-software-engineer.md"]
+  "keywords": [
+    "typescript",
+    "csharp",
+    "sql",
+    "fullstack"
+  ],
+  "agents": [
+    "./agents/bitwarden-software-engineer.md"
+  ]
 }

--- a/plugins/bitwarden-software-engineer/CHANGELOG.md
+++ b/plugins/bitwarden-software-engineer/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the `bitwarden-software-engineer` plugin will be document
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.2] - 2026-05-13
+
+### Fixed
+
+- Added `dotnet format` to the server repo verification steps so the agent auto-corrects encoding and style violations (including BOM) after file edits.
+
 ## [0.4.1] - 2026-05-07
 
 ### Fixed

--- a/plugins/bitwarden-software-engineer/agents/bitwarden-software-engineer.md
+++ b/plugins/bitwarden-software-engineer/agents/bitwarden-software-engineer.md
@@ -34,6 +34,7 @@ After making changes, always verify your work before declaring done. Use the app
 ### Server repo (C#/.NET)
 
 - **Build:** `dotnet build` from the solution root
+- **Format:** `dotnet format` to fix encoding and style violations (including BOM)
 - **Unit tests:** `dotnet test` targeting the relevant test project (e.g., `test/Core.Test`)
 - **Integration tests:** Run tests with `[DatabaseData]` attribute when database changes are involved
 


### PR DESCRIPTION
## 🎟️ Tracking

No ticket — targeted fix proposed from observed agent behavior.

## 📔 Objective

Adds `dotnet format` to the server repo verification sequence in the `bitwarden-software-engineer` agent.

Previously the agent's post-edit verification for C#/.NET work was: build → test. Without a format step, encoding violations and style drift (including BOM insertion by agent) would pass build and test undetected, accumulating silently until a human caught them in review or by manually formatting.

The fix adds one line to the **Verification / Server repo** section of the agent instructions:

```
- **Format:** `dotnet format` to fix encoding and style violations (including BOM)
```

The instruction sits between build and unit tests, matching the conventional fix-then-verify order. It is unconditional — the section already says "always verify your work before declaring done."

This also gives server work verification parity with clients, which includes a `format` instruction.

## 🧪 Testing

Verified by dispatching the modified agent (`0.4.2`, loaded from the local plugin path, **not** the marketplace-installed `0.4.1`) against `~/src/bw/server` on the `test-engineer-agent` branch.

<details><summary>Two independent tasks were run to establish consistency</summary>

| Task | Change | `dotnet format` called? | Result |
|---|---|---|---|
| Minimal edit | `// test-format-run` comment in `Constants.cs` | Yes — Bash tool call, not prose | PASS |
| Non-trivial edit | `GetBuildLabel()` method added to `CoreHelpers.cs` | Yes — `dotnet format --verify-no-changes` | PASS |

Both tasks also ran the revert path (restore original file → full verification sequence again), with `dotnet format` firing in all four rounds.

> **Note for reviewers:** `test-engineer-agent` has 5 pre-existing test failures in `Bit.Core.Test.Dirt.Services.EventIntegrationHandlerTests`. These are unrelated to this PR and present on the branch independent of any changes here.

</details>

<details><summary>To verify locally</summary>

1. Check out this branch and confirm the local plugin version is `0.4.2` in `plugins/bitwarden-software-engineer/.claude-plugin/plugin.json`.
2. Open Claude Code **from the `ai-plugins` repo root** (so the local agent overrides the marketplace-installed version).
3. Dispatch the `bitwarden-software-engineer` agent with any task that writes or edits a `.cs` file in the server repo.
4. Confirm `dotnet format` appears as a Bash tool call in the verification sequence.

</details>
