### PR TITLE
Claude Code bump to version 148

### DIFF
--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -167,7 +167,7 @@ jobs:
         id: components
         if: steps.changed-files.outputs.has_components == 'true'
         continue-on-error: true
-        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1.0.133
+        uses: anthropics/claude-code-action@d5726de019ec4498aa667642bc3a80fca83aa102 # v1.0.148
         with:
           anthropic_api_key: ${{ steps.get-kv-secrets.outputs.ANTHROPIC-CODE-REVIEW-API-KEY }}
           plugin_marketplaces: |


### PR DESCRIPTION
## 🎟️ Tracking

N/A 

## 📔 Objective

Bumping to the latest version of the Claude Code action. Aligning with https://github.com/bitwarden/gh-actions/pull/819
