### PR TITLE
[AI-55] fix: Capture skills invoked by slash command

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -96,7 +96,7 @@
     {
       "name": "bitwarden-ai-telemetry",
       "source": "./plugins/bitwarden-ai-telemetry",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "description": "Claude Code hooks emitting metadata-only AI-usage telemetry (identity, git-linkage, MCP) via OTLP."
     },
     {

--- a/.cspell.json
+++ b/.cspell.json
@@ -126,6 +126,7 @@
     "tarpit",
     "Testmo",
     "thumbsup",
+    "timespec",
     "tinyui",
     "touchpoint",
     "touchpoints",

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A curated collection of plugins for AI-assisted development at Bitwarden. Enable
 
 | Plugin                                                              | Version | Description                                                                                                                                                 |
 | ------------------------------------------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [bitwarden-ai-telemetry](plugins/bitwarden-ai-telemetry/)           | 1.0.0   | Claude Code hooks emitting metadata-only AI-usage telemetry (identity, git-linkage, MCP) via OTLP                                                           |
+| [bitwarden-ai-telemetry](plugins/bitwarden-ai-telemetry/)           | 1.1.0   | Claude Code hooks emitting metadata-only AI-usage telemetry (identity, git-linkage, MCP) via OTLP                                                           |
 | [bitwarden-tech-lead](plugins/bitwarden-tech-lead/)                 | 3.0.0   | Tech lead for technical planning, architecture coherence, and surfacing patterns to Technical Strategy Ideas                                                |
 | [bitwarden-shepherd](plugins/bitwarden-shepherd/)                   | 1.0.1   | Champion of a technical strategy — shepherds a TSI through evaluation into the funnel, then through to adoption                                             |
 | [bitwarden-atlassian-tools](plugins/bitwarden-atlassian-tools/)     | 2.4.0   | Read-only Atlassian access via MCP server with deep Jira issue research skill                                                                               |

--- a/plugins/bitwarden-ai-telemetry/.claude-plugin/plugin.json
+++ b/plugins/bitwarden-ai-telemetry/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bitwarden-ai-telemetry",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Claude Code hooks that emit metadata-only AI-usage telemetry (identity, git-linkage, MCP) as OTLP logs. Fail-open.",
   "author": {
     "name": "Bitwarden",

--- a/plugins/bitwarden-ai-telemetry/CHANGELOG.md
+++ b/plugins/bitwarden-ai-telemetry/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to the bitwarden-ai-telemetry plugin will be documented in t
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2026-07-31
+
+### Added
+
+- `UserPromptExpansion` hook, so skills invoked by slash command (`/plugin:skill`) are recorded. These were previously invisible: Claude Code expands a slash invocation into the prompt rather than dispatching the Skill tool, so `PostToolUse` never fires and `tool_input.skill` never exists. `UserPromptExpansion.command_name` is the only signal that carries the name.
+- `event.timestamp` on every emitted record — ISO-8601 UTC with millisecond precision, matching native Claude Code's shape. Consumers previously had no client clock on these events and fell back to collector ingest time. A caller supplying its own non-empty value keeps it.
+
+### Fixed
+
+- Per-skill usage counts were understated for anyone who invokes skills by slash. Measured before this change: one user had 37 native skill activations, only 13 of which were Skill tool calls, so roughly two thirds of their skill usage produced no telemetry at all.
+
+### Notes
+
+- A slash expansion is recorded with `bw.tool = "Skill"` even though no tool ran, so it matches the same `@bw.tool:Skill` queries as the tool path. `bw.hook` distinguishes the origin (`UserPromptExpansion` vs `PostToolUse`).
+- `command_name` may name a plugin _command_ rather than a skill. The two are deliberately not distinguished.
+- Expansion types other than `slash_command` are suppressed rather than emitted, since they carry no skill identity and would otherwise write content-free `bw.identity` rows.
+
 ## [1.0.0] - 2026-07-01
 
 ### Added

--- a/plugins/bitwarden-ai-telemetry/README.md
+++ b/plugins/bitwarden-ai-telemetry/README.md
@@ -4,15 +4,15 @@ Claude Code hooks that emit **metadata-only** AI-usage telemetry as [OTLP](https
 
 ## What it does
 
-The plugin registers Claude Code lifecycle hooks (`PostToolUse` and `SubagentStop`) that fire after tool use and subagent completion. Each hook POSTs a single OTLP-JSON log record describing what happened, using metadata only. The hooks emit four event families:
+The plugin registers Claude Code lifecycle hooks (`PostToolUse`, `SubagentStop`, and `UserPromptExpansion`) that fire after tool use, subagent completion, and prompt expansion. Each hook POSTs a single OTLP-JSON log record describing what happened, using metadata only. The hooks emit four event families:
 
-| Event         | Fires on                                           | Recovers                                                                                    |
-| ------------- | -------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| `bw.identity` | `Task` / `Agent` / `Skill` tool use; subagent stop | Skill and agent names that native telemetry redacts                                         |
-| `bw.edit`     | `Edit` / `MultiEdit` / `Write` / `NotebookEdit`    | Repo slug, branch, base SHA, and the edited file **path**                                   |
-| `bw.commit`   | `Bash` running `git commit`                        | Repo slug, branch, and the resulting commit **SHA**                                         |
-| `bw.pr`       | `Bash` running `gh pr create`                      | Repo slug, branch, and the **PR number**                                                    |
-| `bw.mcp`      | Any `mcp__*` tool                                  | The real `mcp__<server>__<tool>` name that native telemetry redacts to a generic identifier |
+| Event         | Fires on                                                                  | Recovers                                                                                    |
+| ------------- | ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `bw.identity` | `Task` / `Agent` / `Skill` tool use; subagent stop; `UserPromptExpansion` | Skill and agent names that native telemetry redacts                                         |
+| `bw.edit`     | `Edit` / `MultiEdit` / `Write` / `NotebookEdit`                           | Repo slug, branch, base SHA, and the edited file **path**                                   |
+| `bw.commit`   | `Bash` running `git commit`                                               | Repo slug, branch, and the resulting commit **SHA**                                         |
+| `bw.pr`       | `Bash` running `gh pr create`                                             | Repo slug, branch, and the **PR number**                                                    |
+| `bw.mcp`      | Any `mcp__*` tool                                                         | The real `mcp__<server>__<tool>` name that native telemetry redacts to a generic identifier |
 
 ## What it collects
 

--- a/plugins/bitwarden-ai-telemetry/hooks/emit.py
+++ b/plugins/bitwarden-ai-telemetry/hooks/emit.py
@@ -9,10 +9,23 @@ import json
 import os
 import time
 import urllib.request
+from datetime import datetime, timezone
 from urllib.parse import urlsplit
 
 _ALLOWED_COLLECTOR_HOST = "bitwarden.pw"
 _ALLOWED_COLLECTOR_SUFFIX = ".bitwarden.pw"
+
+
+def _now_iso():
+    """Client event time as ISO-8601 UTC with millisecond precision.
+
+    Mirrors the shape of native Claude Code's `event.timestamp`
+    (`2026-06-10T21:25:21.770Z`) so both streams bucket on the same clock
+    rather than on collector ingest time. Milliseconds matter: consumers
+    deduplicate on the timestamp, so second granularity would collapse
+    distinct invocations emitted within the same second.
+    """
+    return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
 
 
 def _is_allowed_collector(url):
@@ -42,9 +55,16 @@ def emit(body_name, attrs):
     """POST one OTLP-JSON log record. ``attrs`` is a dict of str -> value;
     empty/falsey values are dropped. No-op when BW_TELEMETRY_OTLP isn't set,
     isn't https, or isn't a bitwarden.pw host. Fail-open otherwise: any error
-    returns silently."""
+    returns silently.
+
+    Every record carries `event.timestamp`, so consumers get a client clock
+    instead of falling back to collector ingest time. A caller that supplies
+    its own non-empty value keeps it; the caller's dict is never mutated."""
     if not COLLECTOR:
         return
+    attrs = dict(attrs)
+    if not attrs.get("event.timestamp"):
+        attrs["event.timestamp"] = _now_iso()
     kv = [{"key": k, "value": {"stringValue": str(v)}}
           for k, v in attrs.items() if v]
     payload = {"resourceLogs": [{

--- a/plugins/bitwarden-ai-telemetry/hooks/emit_identity.py
+++ b/plugins/bitwarden-ai-telemetry/hooks/emit_identity.py
@@ -8,6 +8,36 @@ import sys
 
 from emit import emit  # sibling module; script dir is on sys.path[0]
 
+EXPANSION_HOOK = "UserPromptExpansion"
+SLASH_EXPANSION = "slash_command"
+SKILL_TOOL = "Skill"
+
+
+def _slash_skill(h):
+    """The skill name from a slash invocation, or "" if this isn't one.
+
+    A slash-invoked skill (`/plugin:skill`) never produces a Skill tool call —
+    Claude Code expands it into the prompt instead — so PostToolUse never fires
+    and `tool_input.skill` does not exist. UserPromptExpansion is the only event
+    that carries the name, in `command_name`. Verified empirically 2026-07-30;
+    this path was previously invisible to telemetry entirely.
+    """
+    if h.get("expansion_type") != SLASH_EXPANSION:
+        return ""
+    return h.get("command_name") or ""
+
+
+def _should_emit(h):
+    """UserPromptExpansion fires for expansion types beyond slash commands.
+
+    Only slash expansions carry a skill identity; emitting for the others would
+    add content-free bw.identity rows (every bw.* field empty and therefore
+    dropped by emit()), which already pollute counts of @event.name:bw.identity.
+    """
+    if h.get("hook_event_name") == EXPANSION_HOOK:
+        return bool(_slash_skill(h))
+    return True
+
 
 def _build_identity_attrs(h):
     """Reduce one hook-invocation dict to the bw.identity attrs.
@@ -16,15 +46,23 @@ def _build_identity_attrs(h):
     `tool_input.subagent_type` (set on a Task|Agent PostToolUse dispatch) —
     the two hooks fire for different event shapes, never both populated at
     once in practice, but SubagentStop's is the more authoritative of the two
-    when both exist. skill comes from tool_input.skill (a Skill dispatch).
+    when both exist. skill comes from tool_input.skill (a Skill dispatch) or,
+    for a slash invocation, from UserPromptExpansion's command_name.
+
+    A slash expansion reports bw.tool = "Skill" even though no tool ran, so it
+    joins the same `@bw.tool:Skill` queries as the tool path; bw.hook preserves
+    the true origin ("UserPromptExpansion" vs "PostToolUse") for anyone who
+    needs to tell the two apart. Note command_name may name a plugin *command*
+    rather than a skill — the two are deliberately not distinguished.
     """
     tin = h.get("tool_input") or {}
+    slash_skill = _slash_skill(h)
     return {
         "event.name": "bw.identity",
         "bw.hook": h.get("hook_event_name", ""),
         "bw.agent_type": h.get("agent_type") or tin.get("subagent_type") or "",
-        "bw.skill": tin.get("skill") or "",
-        "bw.tool": h.get("tool_name", ""),
+        "bw.skill": tin.get("skill") or slash_skill,
+        "bw.tool": h.get("tool_name") or (SKILL_TOOL if slash_skill else ""),
         "session.id": h.get("session_id", ""),
         "repo": os.path.basename(h.get("cwd") or ""),
     }
@@ -34,6 +72,8 @@ def main():
     try:
         h = json.load(sys.stdin)
     except Exception:
+        return
+    if not _should_emit(h):
         return
     emit("bw.identity", _build_identity_attrs(h))
 

--- a/plugins/bitwarden-ai-telemetry/hooks/hooks.json
+++ b/plugins/bitwarden-ai-telemetry/hooks/hooks.json
@@ -11,6 +11,17 @@
         ]
       }
     ],
+    "UserPromptExpansion": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/emit_identity.py\"",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Task|Agent|Skill",

--- a/plugins/bitwarden-ai-telemetry/hooks/test_emit.py
+++ b/plugins/bitwarden-ai-telemetry/hooks/test_emit.py
@@ -13,6 +13,7 @@ import json
 import os
 import sys
 import unittest
+from datetime import datetime, timedelta
 from unittest import mock
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
@@ -61,7 +62,8 @@ class EmitFailClosedTest(unittest.TestCase):
             body = json.loads(req.data)
             attrs = body["resourceLogs"][0]["scopeLogs"][0]["logRecords"][0]["attributes"]
             keys = {a["key"] for a in attrs}
-            self.assertEqual(keys, {"bw.tool"})
+            # event.timestamp is stamped on every record; see EventTimestampTest.
+            self.assertEqual(keys, {"bw.tool", "event.timestamp"})
 
     def test_network_error_is_swallowed_fail_open(self):
         os.environ["BW_TELEMETRY_OTLP"] = "https://example.bitwarden.pw/v1/logs"
@@ -103,6 +105,58 @@ class EmitFailClosedTest(unittest.TestCase):
         with mock.patch("urllib.request.urlopen") as urlopen:
             emit_module.emit("bw.identity", {"bw.skill": "x"})
             urlopen.assert_not_called()
+
+
+class EventTimestampTest(unittest.TestCase):
+    """Every record carries a client-side event.timestamp so consumers don't
+    fall back to collector ingest time."""
+
+    def setUp(self):
+        self._env_patch = mock.patch.dict(os.environ, {}, clear=False)
+        self._env_patch.start()
+        os.environ["BW_TELEMETRY_OTLP"] = "https://example.bitwarden.pw/v1/logs"
+        importlib.reload(emit_module)
+
+    def tearDown(self):
+        self._env_patch.stop()
+        importlib.reload(emit_module)
+
+    def _attrs_for(self, attrs):
+        with mock.patch("urllib.request.urlopen") as urlopen:
+            urlopen.return_value.read.return_value = b""
+            emit_module.emit("bw.identity", attrs)
+            body = json.loads(urlopen.call_args[0][0].data)
+        records = body["resourceLogs"][0]["scopeLogs"][0]["logRecords"][0]
+        return {a["key"]: a["value"]["stringValue"] for a in records["attributes"]}
+
+    def test_timestamp_is_added_when_absent(self):
+        self.assertIn("event.timestamp", self._attrs_for({"bw.tool": "Skill"}))
+
+    def test_timestamp_parses_as_utc_iso8601(self):
+        raw = self._attrs_for({"bw.tool": "Skill"})["event.timestamp"]
+        self.assertTrue(raw.endswith("Z"), raw)
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+        self.assertEqual(parsed.tzinfo.utcoffset(parsed), timedelta(0))
+
+    def test_timestamp_has_millisecond_precision(self):
+        # Second granularity would collapse distinct same-second invocations
+        # under a consumer deduplication key that includes the timestamp.
+        raw = self._attrs_for({"bw.tool": "Skill"})["event.timestamp"]
+        self.assertRegex(raw, r"\.\d{3}Z$")
+
+    def test_caller_supplied_timestamp_is_preserved(self):
+        supplied = "2026-06-10T21:25:21.770Z"
+        got = self._attrs_for({"bw.tool": "Skill", "event.timestamp": supplied})
+        self.assertEqual(got["event.timestamp"], supplied)
+
+    def test_empty_caller_timestamp_falls_back_to_generated(self):
+        got = self._attrs_for({"bw.tool": "Skill", "event.timestamp": ""})
+        self.assertRegex(got["event.timestamp"], r"\.\d{3}Z$")
+
+    def test_caller_dict_is_not_mutated(self):
+        caller = {"bw.tool": "Skill"}
+        self._attrs_for(caller)
+        self.assertEqual(caller, {"bw.tool": "Skill"})
 
 
 class IsAllowedCollectorTest(unittest.TestCase):

--- a/plugins/bitwarden-ai-telemetry/hooks/test_emit_identity.py
+++ b/plugins/bitwarden-ai-telemetry/hooks/test_emit_identity.py
@@ -12,7 +12,7 @@ import unittest
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-from emit_identity import _build_identity_attrs
+from emit_identity import _build_identity_attrs, _should_emit
 
 
 class BuildIdentityAttrsTest(unittest.TestCase):
@@ -65,6 +65,87 @@ class BuildIdentityAttrsTest(unittest.TestCase):
     def test_repo_is_basename_only(self):
         attrs = _build_identity_attrs({"cwd": "/Users/dev/bitwarden/ai-plugins"})
         self.assertEqual(attrs["repo"], "ai-plugins")
+
+
+class SlashExpansionTest(unittest.TestCase):
+    """A slash-invoked skill fires no Skill tool call, so UserPromptExpansion's
+    command_name is the only carrier of the name."""
+
+    SLASH = {
+        "hook_event_name": "UserPromptExpansion",
+        "expansion_type": "slash_command",
+        "command_name": "bitwarden-delivery-tools:labeling-changes",
+        "command_args": "what are the supported labels?",
+        "command_source": "plugin",
+        "session_id": "session-4",
+        "cwd": "/Users/dev/bitwarden/clients",
+    }
+
+    def test_slash_expansion_recovers_skill_name(self):
+        attrs = _build_identity_attrs(self.SLASH)
+        self.assertEqual(attrs["bw.skill"], "bitwarden-delivery-tools:labeling-changes")
+
+    def test_slash_expansion_reports_skill_tool_for_query_parity(self):
+        attrs = _build_identity_attrs(self.SLASH)
+        self.assertEqual(attrs["bw.tool"], "Skill")
+
+    def test_slash_expansion_preserves_true_origin_in_bw_hook(self):
+        attrs = _build_identity_attrs(self.SLASH)
+        self.assertEqual(attrs["bw.hook"], "UserPromptExpansion")
+
+    def test_slash_expansion_sets_no_agent_type(self):
+        attrs = _build_identity_attrs(self.SLASH)
+        self.assertEqual(attrs["bw.agent_type"], "")
+
+    def test_plugin_command_is_recorded_like_a_skill(self):
+        # command == skill by design; the two are deliberately not distinguished.
+        attrs = _build_identity_attrs({
+            **self.SLASH, "command_name": "bitwarden-code-review:code-review-local",
+        })
+        self.assertEqual(attrs["bw.skill"], "bitwarden-code-review:code-review-local")
+
+    def test_tool_path_still_wins_over_expansion(self):
+        attrs = _build_identity_attrs({
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Skill",
+            "tool_input": {"skill": "tool-path:skill"},
+            "expansion_type": "slash_command",
+            "command_name": "expansion:skill",
+        })
+        self.assertEqual(attrs["bw.skill"], "tool-path:skill")
+        self.assertEqual(attrs["bw.tool"], "Skill")
+
+    def test_non_slash_expansion_yields_no_skill(self):
+        attrs = _build_identity_attrs({
+            "hook_event_name": "UserPromptExpansion",
+            "expansion_type": "not-a-slash-command",
+            "command_name": "something-else",
+        })
+        self.assertEqual(attrs["bw.skill"], "")
+        self.assertEqual(attrs["bw.tool"], "")
+
+
+class ShouldEmitTest(unittest.TestCase):
+    def test_slash_expansion_emits(self):
+        self.assertTrue(_should_emit(SlashExpansionTest.SLASH))
+
+    def test_non_slash_expansion_is_suppressed(self):
+        # Would otherwise write a content-free bw.identity row.
+        self.assertFalse(_should_emit({
+            "hook_event_name": "UserPromptExpansion",
+            "expansion_type": "not-a-slash-command",
+            "command_name": "something-else",
+        }))
+
+    def test_expansion_without_command_name_is_suppressed(self):
+        self.assertFalse(_should_emit({
+            "hook_event_name": "UserPromptExpansion",
+            "expansion_type": "slash_command",
+        }))
+
+    def test_non_expansion_hooks_always_emit(self):
+        self.assertTrue(_should_emit({"hook_event_name": "PostToolUse", "tool_name": "Skill"}))
+        self.assertTrue(_should_emit({"hook_event_name": "SubagentStop"}))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 🎟️ Tracking

[AI-55](https://bitwarden.atlassian.net/browse/AI-55)

## 📔 Objective

Skills invoked by slash command (`/plugin:skill`) produced no telemetry at all, so per-skill usage counts understated real usage.

Claude Code treats a slash invocation as a **prompt expansion**, not a Skill tool dispatch — it injects the skill body as a user message rather than calling the Skill tool. `PostToolUse` therefore never fires and `tool_input.skill` never exists, so `emit_identity.py`'s `Task|Agent|Skill` matcher never matches. Native telemetry still emits `skill_activated`, which is why the gap was visible at all. `UserPromptExpansion` is the only hook event carrying the skill name, in `command_name`.

<details>
<summary>Investigation detail — measured impact and how the mechanism was established</summary>

Measured on live Datadog before this change:

| | activations | Skill tool calls | recorded by us |
|---|---|---|---|
| fleet | 179 | 135 | — |
| worst-affected user | 37 | 13 | 12 |

Roughly 25% of activations were invisible fleet-wide, and about two thirds for the heaviest slash user — whose `committing-changes` count read 1 against roughly 20 real uses.

The mechanism was established by tracing all ~30 subscribable hook events during a slash invocation. Ten fired; none carried `tool_name = "Skill"`. The only tool call in the session was an incidental `Read` of the skill's own reference file.

</details>

### Changes

- Subscribe to `UserPromptExpansion` and emit `bw.identity` with `bw.skill` taken from `command_name`.
- Stamp `event.timestamp` (ISO-8601 UTC, millisecond precision) on **every** emitted record in the shared `emit()`, so all `bw.*` events carry a client clock rather than consumers falling back to collector ingest time. Millisecond precision matters because downstream deduplication keys include the timestamp.

### Notes for reviewers

- **Datadog dashboards need no query change.** They already read `@bw.tool:Skill`, so their counts correct themselves once this ships — no dashboard work is required alongside this PR.
- **No collector change either.** `bw.skill`, `bw.tool`, `bw.hook` and `event.timestamp` are all already on the middleware allowlist.
- A slash expansion is recorded with `bw.tool = "Skill"` even though no tool ran, so it matches the same `@bw.tool:Skill` queries as the tool path. `bw.hook` preserves the true origin (`UserPromptExpansion` vs `PostToolUse`).
- `command_name` may name a plugin **command** rather than a skill. The two are deliberately not distinguished.
- Expansion types other than `slash_command` are suppressed rather than emitted — they carry no skill identity and would write content-free `bw.identity` rows.
- Built-in commands (`/clear`, `/plugin`) fire no prompt hook at all, so they cannot pollute counts.
- A caller supplying its own non-empty `event.timestamp` keeps it, and the caller's dict is never mutated.


[AI-55]: https://bitwarden.atlassian.net/browse/AI-55?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ