### PR TITLE
feat(claude-config-validator): write local validation reports to plugin data dir

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -18,7 +18,7 @@
     {
       "name": "claude-config-validator",
       "source": "./plugins/claude-config-validator",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "description": "Validates Claude Code configuration files for security, structure, and quality. Reviews CLAUDE.md, skills, agents, prompts, commands, and settings with comprehensive validation checklists."
     },
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -18,7 +18,7 @@
     {
       "name": "claude-config-validator",
       "source": "./plugins/claude-config-validator",
-      "version": "1.3.0",
+      "version": "1.2.1",
       "description": "Validates Claude Code configuration files for security, structure, and quality. Reviews CLAUDE.md, skills, agents, prompts, commands, and settings with comprehensive validation checklists."
     },
     {

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,5 @@ pnpm-debug.log
 # Local AI review and validation output
 # .claude-pr is claude-code-action's snapshot of PR-authored config; never ours to commit
 .claude-pr/
-validation-summary.md
 review-summary.md
 review-inline-comments.md

--- a/.gitignore
+++ b/.gitignore
@@ -30,5 +30,6 @@ pnpm-debug.log
 # Local AI review and validation output
 # .claude-pr is claude-code-action's snapshot of PR-authored config; never ours to commit
 .claude-pr/
+validation-summary.md
 review-summary.md
 review-inline-comments.md

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A curated collection of plugins for AI-assisted development at Bitwarden. Enable
 | [bitwarden-security-engineer](plugins/bitwarden-security-engineer/) | 1.3.0   | Application security engineering: vulnerability triage, threat modeling, and secure code analysis                                                           |
 | [bitwarden-software-engineer](plugins/bitwarden-software-engineer/) | 1.0.0   | Software engineer agent for a Bitwarden product team. Implements stories, tasks, and bugs with code quality, performance, security, and team comms in mind. |
 | [bitwarden-testing-tools](plugins/bitwarden-testing-tools/)         | 1.0.0   | Testing tools for analyzing and improving test quality across Bitwarden's repositories.                                                                     |
-| [claude-config-validator](plugins/claude-config-validator/)         | 1.3.0   | Validates Claude Code configuration files for security, structure, and quality                                                                              |
+| [claude-config-validator](plugins/claude-config-validator/)         | 1.2.1   | Validates Claude Code configuration files for security, structure, and quality                                                                              |
 | [claude-retrospective](plugins/claude-retrospective/)               | 1.1.1   | Analyze Claude Code sessions to identify successful patterns and improvement opportunities                                                                  |
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A curated collection of plugins for AI-assisted development at Bitwarden. Enable
 | [bitwarden-security-engineer](plugins/bitwarden-security-engineer/) | 1.3.0   | Application security engineering: vulnerability triage, threat modeling, and secure code analysis                                                           |
 | [bitwarden-software-engineer](plugins/bitwarden-software-engineer/) | 1.0.0   | Software engineer agent for a Bitwarden product team. Implements stories, tasks, and bugs with code quality, performance, security, and team comms in mind. |
 | [bitwarden-testing-tools](plugins/bitwarden-testing-tools/)         | 1.0.0   | Testing tools for analyzing and improving test quality across Bitwarden's repositories.                                                                     |
-| [claude-config-validator](plugins/claude-config-validator/)         | 1.2.0   | Validates Claude Code configuration files for security, structure, and quality                                                                              |
+| [claude-config-validator](plugins/claude-config-validator/)         | 1.3.0   | Validates Claude Code configuration files for security, structure, and quality                                                                              |
 | [claude-retrospective](plugins/claude-retrospective/)               | 1.1.1   | Analyze Claude Code sessions to identify successful patterns and improvement opportunities                                                                  |
 
 ## Usage

--- a/plugins/claude-config-validator/.claude-plugin/plugin.json
+++ b/plugins/claude-config-validator/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-config-validator",
-  "version": "1.3.0",
+  "version": "1.2.1",
   "description": "Validates Claude Code configuration files for security, structure, and quality. Reviews CLAUDE.md, skills, agents, prompts, commands, and settings with comprehensive validation checklists.",
   "author": {
     "name": "Bitwarden",

--- a/plugins/claude-config-validator/.claude-plugin/plugin.json
+++ b/plugins/claude-config-validator/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-config-validator",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Validates Claude Code configuration files for security, structure, and quality. Reviews CLAUDE.md, skills, agents, prompts, commands, and settings with comprehensive validation checklists.",
   "author": {
     "name": "Bitwarden",

--- a/plugins/claude-config-validator/CHANGELOG.md
+++ b/plugins/claude-config-validator/CHANGELOG.md
@@ -5,13 +5,13 @@ All notable changes to the Claude Config Validator Plugin will be documented in 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.3.0] - 2026-08-14
+## [1.2.1] - 2026-08-14
 
 ### Changed
 
-- `/validate-ai-local` writes its report to `${CLAUDE_PLUGIN_DATA}/ai-validation/<repo>-<timestamp>-validation.md` instead of `validation-summary.md` in the working directory. The command runs against any checkout, so the old location meant every repository it was pointed at needed a `.gitignore` entry to keep the report out of a commit. The repo and timestamp in the name also stop reports from different checkouts overwriting each other. The command prints the path it wrote, since the new location is not one you would stumble across
-- `Write` grant on `/validate-ai-local` is scoped to `~/.claude/plugins/data/**/ai-validation/`, and `Bash(date:*)` is pre-approved for the report timestamp. The grant is home-relative rather than `${CLAUDE_PLUGIN_DATA}`-based because a permission pattern is absolute only in its `~/` or `//` form; the single leading slash the variable expands to would anchor the rule at the current directory and never match. It does not follow `CLAUDE_CODE_PLUGIN_CACHE_DIR`, so a relocated plugin store means the final write asks for permission
-- `description` on `/validate-ai-local` names the new report location, since that string is what `/help` and the command listing show
+- `/validate-ai-local` writes its report to `${CLAUDE_PLUGIN_DATA}/ai-validation/<repo>-<timestamp>-validation.md` instead of the working directory, so no repository it runs against needs a `.gitignore` entry for the report
+- `Write` grant scoped to `~/.claude/plugins/data/**/ai-validation/`, plus `Bash(date:*)` for the report timestamp. The grant is home-relative because a permission pattern is absolute only in its `~/` or `//` form; it does not follow `CLAUDE_CODE_PLUGIN_CACHE_DIR`
+- `/validate-ai-local` description names the report location, which is the string `/help` shows
 
 ## [1.2.0] - 2026-08-12
 

--- a/plugins/claude-config-validator/CHANGELOG.md
+++ b/plugins/claude-config-validator/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `/validate-ai-local` writes its report to `${CLAUDE_PLUGIN_DATA}/ai-validation/<repo>-<timestamp>-validation.md` instead of the working directory, so no repository it runs against needs a `.gitignore` entry for the report
-- `Write` grant scoped to `~/.claude/plugins/data/*/ai-validation/`, plus `Bash(date:*)` for the report timestamp. The grant is home-relative because a permission pattern is absolute only in its `~/` or `//` form; it does not follow `CLAUDE_CONFIG_DIR`
+- `Write` grant scoped to `~/.claude/plugins/data/claude-config-validator-*/ai-validation/`, plus `Bash(date:*)` for the report timestamp. The grant is home-relative because a permission pattern is absolute only in its `~/` or `//` form; it does not follow `CLAUDE_CONFIG_DIR` or `CLAUDE_CODE_PLUGIN_CACHE_DIR`
 - `/validate-ai-local` description names the report location, which is the string `/help` shows
 
 ## [1.2.0] - 2026-08-12

--- a/plugins/claude-config-validator/CHANGELOG.md
+++ b/plugins/claude-config-validator/CHANGELOG.md
@@ -10,13 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `/validate-ai-local` writes its report to `${CLAUDE_PLUGIN_DATA}/ai-validation/<repo>-<timestamp>-validation.md` instead of the working directory, so no repository it runs against needs a `.gitignore` entry for the report
-- `Edit` rule scoped to `~/.claude/plugins/data/claude-config-validator-*/ai-validation/`, plus `Bash(date:*)` for the report timestamp. The path is written literally because substitution in `allowed-tools` is documented for Bash rules only; it therefore does not follow `CLAUDE_CONFIG_DIR` or `CLAUDE_CODE_PLUGIN_CACHE_DIR`
+- `Edit` rule scoped to `~/.claude/plugins/data/claude-config-validator*/ai-validation/`, plus `Bash(date:*)` for the report timestamp. The path is written literally because substitution in `allowed-tools` is documented for Bash rules only; it therefore does not follow `CLAUDE_CONFIG_DIR` or `CLAUDE_CODE_PLUGIN_CACHE_DIR`
 - `/validate-ai-local` description names the report location, which is the string `/help` shows
 
 ### Fixed
 
-- Both commands declared their report file as a `Write` path rule. Claude Code consults `Edit(path)` and `Read(path)` rules only, so a `Write` path rule is accepted, never consulted, and warned about at startup, leaving each command's mandatory final write unapproved. Both are now `Edit` rules, which cover every built-in file-editing tool
-- Dropped the unexercised `Bash(ls:*)` grant from both commands
+- Both commands declared their report file as a `Write` path rule. Claude Code consults `Edit(path)` and `Read(path)` rules only, so a `Write` path rule is accepted, never consulted, and warned about at startup, leaving each command's mandatory final write unapproved. Both are now `Edit` rules, which cover every built-in file-editing tool. Requires Claude Code 2.1.210 or later; on an older CLI the write asks for permission
 
 ## [1.2.0] - 2026-08-12
 

--- a/plugins/claude-config-validator/CHANGELOG.md
+++ b/plugins/claude-config-validator/CHANGELOG.md
@@ -10,8 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `/validate-ai-local` writes its report to `${CLAUDE_PLUGIN_DATA}/ai-validation/<repo>-<timestamp>-validation.md` instead of the working directory, so no repository it runs against needs a `.gitignore` entry for the report
-- `Write` grant scoped to `~/.claude/plugins/data/claude-config-validator-*/ai-validation/`, plus `Bash(date:*)` for the report timestamp. The grant is home-relative because a permission pattern is absolute only in its `~/` or `//` form; it does not follow `CLAUDE_CONFIG_DIR` or `CLAUDE_CODE_PLUGIN_CACHE_DIR`
+- `Edit` rule scoped to `~/.claude/plugins/data/claude-config-validator-*/ai-validation/`, plus `Bash(date:*)` for the report timestamp. The path is written literally because substitution in `allowed-tools` is documented for Bash rules only; it therefore does not follow `CLAUDE_CONFIG_DIR` or `CLAUDE_CODE_PLUGIN_CACHE_DIR`
 - `/validate-ai-local` description names the report location, which is the string `/help` shows
+
+### Fixed
+
+- Both commands declared their report file as a `Write` path rule. Claude Code consults `Edit(path)` and `Read(path)` rules only, so a `Write` path rule is accepted, never consulted, and warned about at startup, leaving each command's mandatory final write unapproved. Both are now `Edit` rules, which cover every built-in file-editing tool
+- Dropped the unexercised `Bash(ls:*)` grant from both commands
 
 ## [1.2.0] - 2026-08-12
 

--- a/plugins/claude-config-validator/CHANGELOG.md
+++ b/plugins/claude-config-validator/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the Claude Config Validator Plugin will be documented in 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2026-08-14
+
+### Changed
+
+- `/validate-ai-local` writes its report to `${CLAUDE_PLUGIN_DATA}/ai-validation/<repo>-<timestamp>-validation.md` instead of `validation-summary.md` in the working directory. The command runs against any checkout, so the old location meant every repository it was pointed at needed a `.gitignore` entry to keep the report out of a commit. The repo and timestamp in the name also stop reports from different checkouts overwriting each other. The command prints the path it wrote, since the new location is not one you would stumble across
+- `Write` grant on `/validate-ai-local` is scoped to `${CLAUDE_PLUGIN_DATA}/ai-validation/`, and `Bash(date:*)` is pre-approved for the report timestamp
+
 ## [1.2.0] - 2026-08-12
 
 ### Added

--- a/plugins/claude-config-validator/CHANGELOG.md
+++ b/plugins/claude-config-validator/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `/validate-ai-local` writes its report to `${CLAUDE_PLUGIN_DATA}/ai-validation/<repo>-<timestamp>-validation.md` instead of `validation-summary.md` in the working directory. The command runs against any checkout, so the old location meant every repository it was pointed at needed a `.gitignore` entry to keep the report out of a commit. The repo and timestamp in the name also stop reports from different checkouts overwriting each other. The command prints the path it wrote, since the new location is not one you would stumble across
-- `Write` grant on `/validate-ai-local` is scoped to `${CLAUDE_PLUGIN_DATA}/ai-validation/`, and `Bash(date:*)` is pre-approved for the report timestamp
+- `Write` grant on `/validate-ai-local` is scoped to `~/.claude/plugins/data/**/ai-validation/`, and `Bash(date:*)` is pre-approved for the report timestamp. The grant is home-relative rather than `${CLAUDE_PLUGIN_DATA}`-based because a permission pattern is absolute only in its `~/` or `//` form; the single leading slash the variable expands to would anchor the rule at the current directory and never match. It does not follow `CLAUDE_CODE_PLUGIN_CACHE_DIR`, so a relocated plugin store means the final write asks for permission
+- `description` on `/validate-ai-local` names the new report location, since that string is what `/help` and the command listing show
 
 ## [1.2.0] - 2026-08-12
 

--- a/plugins/claude-config-validator/CHANGELOG.md
+++ b/plugins/claude-config-validator/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `/validate-ai-local` writes its report to `${CLAUDE_PLUGIN_DATA}/ai-validation/<repo>-<timestamp>-validation.md` instead of the working directory, so no repository it runs against needs a `.gitignore` entry for the report
-- `Edit` rule scoped to `~/.claude/plugins/data/claude-config-validator*/ai-validation/`, plus `Bash(date:*)` for the report timestamp. The path is written literally because substitution in `allowed-tools` is documented for Bash rules only; it therefore does not follow `CLAUDE_CONFIG_DIR` or `CLAUDE_CODE_PLUGIN_CACHE_DIR`
+- `Edit` rule scoped to `~/.claude/plugins/data/claude-config-validator*/ai-validation/`, plus `Bash(date:*)` for the report timestamp. The path is written literally rather than as `${CLAUDE_PLUGIN_DATA}` because that substitution is skipped for a local `--plugin-dir` load; it therefore does not follow `CLAUDE_CONFIG_DIR` or `CLAUDE_CODE_PLUGIN_CACHE_DIR`
 - `/validate-ai-local` description names the report location, which is the string `/help` shows
 
 ### Fixed

--- a/plugins/claude-config-validator/CHANGELOG.md
+++ b/plugins/claude-config-validator/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `/validate-ai-local` writes its report to `${CLAUDE_PLUGIN_DATA}/ai-validation/<repo>-<timestamp>-validation.md` instead of the working directory, so no repository it runs against needs a `.gitignore` entry for the report
-- `Write` grant scoped to `~/.claude/plugins/data/**/ai-validation/`, plus `Bash(date:*)` for the report timestamp. The grant is home-relative because a permission pattern is absolute only in its `~/` or `//` form; it does not follow `CLAUDE_CODE_PLUGIN_CACHE_DIR`
+- `Write` grant scoped to `~/.claude/plugins/data/*/ai-validation/`, plus `Bash(date:*)` for the report timestamp. The grant is home-relative because a permission pattern is absolute only in its `~/` or `//` form; it does not follow `CLAUDE_CONFIG_DIR`
 - `/validate-ai-local` description names the report location, which is the string `/help` shows
 
 ## [1.2.0] - 2026-08-12

--- a/plugins/claude-config-validator/README.md
+++ b/plugins/claude-config-validator/README.md
@@ -79,10 +79,10 @@ Provides specific, file:line referenced feedback with:
 
 ### Commands
 
-| Command                                                      | Purpose                                                                                                                   |
-| ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------- |
-| [`/validate-ai-local`](commands/validate-ai-local/README.md) | Validate the Claude material you changed locally (branch commits plus uncommitted work) and write `validation-summary.md` |
-| [`/validate-ai`](commands/validate-ai/README.md)             | Validate the Claude material changed in a pull request and report to a sticky pull request comment                        |
+| Command                                                      | Purpose                                                                                                                                              |
+| ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`/validate-ai-local`](commands/validate-ai-local/README.md) | Validate the Claude material you changed locally (branch commits plus uncommitted work) and write a report to `${CLAUDE_PLUGIN_DATA}/ai-validation/` |
+| [`/validate-ai`](commands/validate-ai/README.md)             | Validate the Claude material changed in a pull request and report to a sticky pull request comment                                                   |
 
 Both commands run the same review the
 [validate-ai](https://github.com/bitwarden/gh-actions/tree/main/validate-ai) GitHub

--- a/plugins/claude-config-validator/commands/validate-ai-local/README.md
+++ b/plugins/claude-config-validator/commands/validate-ai-local/README.md
@@ -79,7 +79,8 @@ in `bitwarden/gh-actions` is their sole source of truth, and they are invoked wi
 
 The command pre-approves read-only inspection only — `git diff`, `git fetch`,
 `git rev-parse`, `git symbolic-ref`, `git ls-files`, `date`, `ls` — plus a `Write` scoped
-to `~/.claude/plugins/data/*/ai-validation/`, the only directory it writes to. Cloning
+to `~/.claude/plugins/data/claude-config-validator-*/ai-validation/`, the only directory it
+writes to. Cloning
 `gh-actions` and running its scripts are left out on purpose and will be asked for: that
 step executes shell code from outside this repository, and a blanket `Bash(bash:*)` grant
 would pre-approve arbitrary commands on the one path that fetches code from the network.
@@ -88,12 +89,11 @@ If you run this often, allowlist the exact script invocations yourself.
 The `Write` grant is written home-relative rather than as `${CLAUDE_PLUGIN_DATA}/...`
 because a permission pattern is only filesystem-absolute in its `~/` or `//` form — the
 single leading slash `${CLAUDE_PLUGIN_DATA}` expands to would anchor the rule at your
-current directory and never match. Two consequences. The `*` standing in for the plugin's
-data directory means the pattern spans any plugin's `ai-validation/` directory rather than
-this one's; naming a single directory would require hardcoding the plugin identifier, which
-embeds the marketplace you installed from and so differs between installs. And the pattern
-is written against `~/.claude`, so if you have relocated that tree with
-`CLAUDE_CONFIG_DIR`, the final write asks for permission.
+current directory and never match. The data directory is named from the plugin's install
+id, which appends the marketplace you installed from, so the trailing `-*` globs that
+suffix while still naming this plugin. The pattern is written against `~/.claude`, so
+relocating the tree with either `CLAUDE_CONFIG_DIR` or `CLAUDE_CODE_PLUGIN_CACHE_DIR` means
+the final write asks for permission.
 
 ## Known local caveat
 

--- a/plugins/claude-config-validator/commands/validate-ai-local/README.md
+++ b/plugins/claude-config-validator/commands/validate-ai-local/README.md
@@ -78,7 +78,7 @@ in `bitwarden/gh-actions` is their sole source of truth, and they are invoked wi
 ## Permissions
 
 The command pre-approves read-only inspection only — `git diff`, `git fetch`,
-`git rev-parse`, `git symbolic-ref`, `git ls-files`, `date`, `ls` — plus a `Write` scoped
+`git rev-parse`, `git symbolic-ref`, `git ls-files`, `date` — plus an `Edit` rule scoped
 to `~/.claude/plugins/data/claude-config-validator-*/ai-validation/`, the only directory it
 writes to. Cloning
 `gh-actions` and running its scripts are left out on purpose and will be asked for: that
@@ -86,14 +86,17 @@ step executes shell code from outside this repository, and a blanket `Bash(bash:
 would pre-approve arbitrary commands on the one path that fetches code from the network.
 If you run this often, allowlist the exact script invocations yourself.
 
-The `Write` grant is written home-relative rather than as `${CLAUDE_PLUGIN_DATA}/...`
-because a permission pattern is only filesystem-absolute in its `~/` or `//` form — the
-single leading slash `${CLAUDE_PLUGIN_DATA}` expands to would anchor the rule at your
-current directory and never match. The data directory is named from the plugin's install
-id, which appends the marketplace you installed from, so the trailing `-*` globs that
-suffix while still naming this plugin. The pattern is written against `~/.claude`, so
-relocating the tree with either `CLAUDE_CONFIG_DIR` or `CLAUDE_CODE_PLUGIN_CACHE_DIR` means
-the final write asks for permission.
+Two details in that rule are deliberate. It is an `Edit` rule even though the command uses
+`Write`, because Claude Code checks file permissions against `Edit(path)` and `Read(path)`
+rules only: a path rule written for `Write` is accepted, never consulted, and warned about
+at startup, while an `Edit` rule applies to every built-in tool that edits files. And the
+path is written out literally rather than as `${CLAUDE_PLUGIN_DATA}/...`, because
+substitution in `allowed-tools` is documented for Bash rules, not for file-path rules. The
+data directory is named from the plugin's install id, which appends the marketplace you
+installed from, so the trailing `-*` globs that suffix while still naming this plugin.
+Because the pattern is written against `~/.claude`, relocating that tree with
+`CLAUDE_CONFIG_DIR` or `CLAUDE_CODE_PLUGIN_CACHE_DIR` means the final write asks for
+permission.
 
 ## Known local caveat
 

--- a/plugins/claude-config-validator/commands/validate-ai-local/README.md
+++ b/plugins/claude-config-validator/commands/validate-ai-local/README.md
@@ -79,7 +79,7 @@ in `bitwarden/gh-actions` is their sole source of truth, and they are invoked wi
 
 The command pre-approves read-only inspection only — `git diff`, `git fetch`,
 `git rev-parse`, `git symbolic-ref`, `git ls-files`, `date`, `ls` — plus a `Write` scoped
-to `~/.claude/plugins/data/**/ai-validation/`, the only directory it writes to. Cloning
+to `~/.claude/plugins/data/*/ai-validation/`, the only directory it writes to. Cloning
 `gh-actions` and running its scripts are left out on purpose and will be asked for: that
 step executes shell code from outside this repository, and a blanket `Bash(bash:*)` grant
 would pre-approve arbitrary commands on the one path that fetches code from the network.
@@ -88,10 +88,12 @@ If you run this often, allowlist the exact script invocations yourself.
 The `Write` grant is written home-relative rather than as `${CLAUDE_PLUGIN_DATA}/...`
 because a permission pattern is only filesystem-absolute in its `~/` or `//` form — the
 single leading slash `${CLAUDE_PLUGIN_DATA}` expands to would anchor the rule at your
-current directory and never match. Two consequences: the pattern spans any plugin's
-`ai-validation/` directory rather than this one's, and it does not follow
-`CLAUDE_CODE_PLUGIN_CACHE_DIR` if you have relocated plugin storage, in which case the
-final write asks for permission.
+current directory and never match. Two consequences. The `*` standing in for the plugin's
+data directory means the pattern spans any plugin's `ai-validation/` directory rather than
+this one's; naming a single directory would require hardcoding the plugin identifier, which
+embeds the marketplace you installed from and so differs between installs. And the pattern
+is written against `~/.claude`, so if you have relocated that tree with
+`CLAUDE_CONFIG_DIR`, the final write asks for permission.
 
 ## Known local caveat
 
@@ -114,7 +116,8 @@ whenever that check runs.
 which can be any repository — so no repository needs a `.gitignore` entry for them, and
 reports from different checkouts do not overwrite each other. The trade-off is that they
 accumulate somewhere you have to go looking for; the command prints the path it wrote each
-time. `/plugin uninstall` deletes that directory unless you pass `--keep-data`.
+time. `claude plugin uninstall <plugin>` deletes that directory unless you pass
+`--keep-data`.
 
 The file is always written, including when everything passes and when every section was
 skipped, and it ends with `<!-- validation-complete -->` so a local report matches what

--- a/plugins/claude-config-validator/commands/validate-ai-local/README.md
+++ b/plugins/claude-config-validator/commands/validate-ai-local/README.md
@@ -100,7 +100,10 @@ required hyphen would fail to match the second case.
 
 Because the pattern is written against `~/.claude`, relocating that tree with
 `CLAUDE_CONFIG_DIR` or `CLAUDE_CODE_PLUGIN_CACHE_DIR` means the final write asks for
-permission.
+permission. On Linux with the Bash sandbox enabled you may also see a startup warning that
+glob patterns in permission rules are not fully supported when deriving sandbox write paths;
+it names this rule, and the report is still written, since the permission check the write
+goes through is a separate path.
 
 ## Known local caveat
 

--- a/plugins/claude-config-validator/commands/validate-ai-local/README.md
+++ b/plugins/claude-config-validator/commands/validate-ai-local/README.md
@@ -78,13 +78,20 @@ in `bitwarden/gh-actions` is their sole source of truth, and they are invoked wi
 ## Permissions
 
 The command pre-approves read-only inspection only — `git diff`, `git fetch`,
-`git rev-parse`, `git symbolic-ref`, `git ls-files`, `date`, `ls` — plus a
-`Write` scoped to `${CLAUDE_PLUGIN_DATA}/ai-validation/`, the only directory it writes to.
-Cloning `gh-actions` and running its scripts are left out on purpose and will be asked
-for: that
+`git rev-parse`, `git symbolic-ref`, `git ls-files`, `date`, `ls` — plus a `Write` scoped
+to `~/.claude/plugins/data/**/ai-validation/`, the only directory it writes to. Cloning
+`gh-actions` and running its scripts are left out on purpose and will be asked for: that
 step executes shell code from outside this repository, and a blanket `Bash(bash:*)` grant
 would pre-approve arbitrary commands on the one path that fetches code from the network.
 If you run this often, allowlist the exact script invocations yourself.
+
+The `Write` grant is written home-relative rather than as `${CLAUDE_PLUGIN_DATA}/...`
+because a permission pattern is only filesystem-absolute in its `~/` or `//` form — the
+single leading slash `${CLAUDE_PLUGIN_DATA}` expands to would anchor the rule at your
+current directory and never match. Two consequences: the pattern spans any plugin's
+`ai-validation/` directory rather than this one's, and it does not follow
+`CLAUDE_CODE_PLUGIN_CACHE_DIR` if you have relocated plugin storage, in which case the
+final write asks for permission.
 
 ## Known local caveat
 
@@ -107,7 +114,7 @@ whenever that check runs.
 which can be any repository — so no repository needs a `.gitignore` entry for them, and
 reports from different checkouts do not overwrite each other. The trade-off is that they
 accumulate somewhere you have to go looking for; the command prints the path it wrote each
-time.
+time. `/plugin uninstall` deletes that directory unless you pass `--keep-data`.
 
 The file is always written, including when everything passes and when every section was
 skipped, and it ends with `<!-- validation-complete -->` so a local report matches what

--- a/plugins/claude-config-validator/commands/validate-ai-local/README.md
+++ b/plugins/claude-config-validator/commands/validate-ai-local/README.md
@@ -78,22 +78,26 @@ in `bitwarden/gh-actions` is their sole source of truth, and they are invoked wi
 ## Permissions
 
 The command pre-approves read-only inspection only — `git diff`, `git fetch`,
-`git rev-parse`, `git symbolic-ref`, `git ls-files`, `date` — plus an `Edit` rule scoped
-to `~/.claude/plugins/data/claude-config-validator-*/ai-validation/`, the only directory it
-writes to. Cloning
+`git rev-parse`, `git symbolic-ref`, `git ls-files`, `date`, `ls` — plus an `Edit` rule
+scoped to `~/.claude/plugins/data/claude-config-validator*/ai-validation/`, the only
+directory it writes to. Cloning
 `gh-actions` and running its scripts are left out on purpose and will be asked for: that
 step executes shell code from outside this repository, and a blanket `Bash(bash:*)` grant
 would pre-approve arbitrary commands on the one path that fetches code from the network.
 If you run this often, allowlist the exact script invocations yourself.
 
-Two details in that rule are deliberate. It is an `Edit` rule even though the command uses
+Three details in that rule are deliberate. It is an `Edit` rule even though the command uses
 `Write`, because Claude Code checks file permissions against `Edit(path)` and `Read(path)`
 rules only: a path rule written for `Write` is accepted, never consulted, and warned about
-at startup, while an `Edit` rule applies to every built-in tool that edits files. And the
-path is written out literally rather than as `${CLAUDE_PLUGIN_DATA}/...`, because
-substitution in `allowed-tools` is documented for Bash rules, not for file-path rules. The
-data directory is named from the plugin's install id, which appends the marketplace you
-installed from, so the trailing `-*` globs that suffix while still naming this plugin.
+at startup, while an `Edit` rule applies to every built-in tool that edits files. That
+behavior needs Claude Code 2.1.210 or later; on an older CLI the write asks for permission
+instead. The path is written out literally rather than as `${CLAUDE_PLUGIN_DATA}/...`,
+because substitution in `allowed-tools` is documented for Bash rules, not for file-path
+rules. And the trailing `*` is loose on purpose: the data directory is named from the
+plugin's install id, which is `claude-config-validator-bitwarden-marketplace` for a
+marketplace install but bare `claude-config-validator` for a local `--plugin-dir` load, so a
+required hyphen would fail to match the second case.
+
 Because the pattern is written against `~/.claude`, relocating that tree with
 `CLAUDE_CONFIG_DIR` or `CLAUDE_CODE_PLUGIN_CACHE_DIR` means the final write asks for
 permission.
@@ -120,7 +124,8 @@ which can be any repository — so no repository needs a `.gitignore` entry for 
 reports from different checkouts do not overwrite each other. The trade-off is that they
 accumulate somewhere you have to go looking for; the command prints the path it wrote each
 time. `claude plugin uninstall <plugin>` deletes that directory unless you pass
-`--keep-data`.
+`--keep-data`; `claude plugin uninstall --help` documents both the flag and the
+`~/.claude/plugins/data/{id}/` layout the `Edit` rule is written against.
 
 The file is always written, including when everything passes and when every section was
 skipped, and it ends with `<!-- validation-complete -->` so a local report matches what

--- a/plugins/claude-config-validator/commands/validate-ai-local/README.md
+++ b/plugins/claude-config-validator/commands/validate-ai-local/README.md
@@ -91,9 +91,11 @@ Three details in that rule are deliberate. It is an `Edit` rule even though the 
 rules only: a path rule written for `Write` is accepted, never consulted, and warned about
 at startup, while an `Edit` rule applies to every built-in tool that edits files. That
 behavior needs Claude Code 2.1.210 or later; on an older CLI the write asks for permission
-instead. The path is written out literally rather than as `${CLAUDE_PLUGIN_DATA}/...`,
-because substitution in `allowed-tools` is documented for Bash rules, not for file-path
-rules. And the trailing `*` is loose on purpose: the data directory is named from the
+instead. The path is written out literally rather than as `${CLAUDE_PLUGIN_DATA}/...`
+because that substitution is skipped for a local `--plugin-dir` load, where it is guarded on
+the plugin having a marketplace source, so the variable can survive into the rule unexpanded
+and match nothing. A literal path covers both install kinds. And the trailing `*` is loose
+on purpose: the data directory is named from the
 plugin's install id, which is `claude-config-validator-bitwarden-marketplace` for a
 marketplace install but bare `claude-config-validator` for a local `--plugin-dir` load, so a
 required hyphen would fail to match the second case.

--- a/plugins/claude-config-validator/commands/validate-ai-local/README.md
+++ b/plugins/claude-config-validator/commands/validate-ai-local/README.md
@@ -5,8 +5,8 @@
 `/validate-ai-local` runs the [validate-ai](https://github.com/bitwarden/gh-actions/tree/main/validate-ai)
 review against your local checkout instead of a pull request. It finds the Claude Code
 material you changed — plugins, agents, skills, commands, hooks, `CLAUDE.md`, `.claude/` —
-runs the same checks CI runs, and writes the report to `validation-summary.md` in your
-working directory. Nothing is posted to GitHub.
+runs the same checks CI runs, and writes the report to the plugin's own data directory.
+Nothing is posted to GitHub.
 
 Use it before you push, so a version bump you forgot or an agent frontmatter mistake
 shows up on your machine rather than as a red check.
@@ -78,9 +78,10 @@ in `bitwarden/gh-actions` is their sole source of truth, and they are invoked wi
 ## Permissions
 
 The command pre-approves read-only inspection only — `git diff`, `git fetch`,
-`git rev-parse`, `git symbolic-ref`, `git ls-files`, `ls` — plus a
-`Write` scoped to the one file it produces, `validation-summary.md`. Cloning
-`gh-actions` and running its scripts are left out on purpose and will be asked for: that
+`git rev-parse`, `git symbolic-ref`, `git ls-files`, `date`, `ls` — plus a
+`Write` scoped to `${CLAUDE_PLUGIN_DATA}/ai-validation/`, the only directory it writes to.
+Cloning `gh-actions` and running its scripts are left out on purpose and will be asked
+for: that
 step executes shell code from outside this repository, and a blanket `Bash(bash:*)` grant
 would pre-approve arbitrary commands on the one path that fetches code from the network.
 If you run this often, allowlist the exact script invocations yourself.
@@ -95,11 +96,18 @@ whenever that check runs.
 
 ## Output
 
-`validation-summary.md` in the current working directory, containing:
+`${CLAUDE_PLUGIN_DATA}/ai-validation/<repo>-<timestamp>-validation.md`, containing:
 
 - Overall result and what was validated against which base
 - Findings grouped as critical, major, and minor, each with `file:line` and a fix
 - A checks table showing what ran, what failed, and what was skipped and why
+
+`${CLAUDE_PLUGIN_DATA}` resolves to this plugin's directory under
+`~/.claude/plugins/data/`. Reports land there rather than in the checkout you validated,
+which can be any repository — so no repository needs a `.gitignore` entry for them, and
+reports from different checkouts do not overwrite each other. The trade-off is that they
+accumulate somewhere you have to go looking for; the command prints the path it wrote each
+time.
 
 The file is always written, including when everything passes and when every section was
 skipped, and it ends with `<!-- validation-complete -->` so a local report matches what
@@ -107,12 +115,12 @@ skipped, and it ends with `<!-- validation-complete -->` so a local report match
 
 ## Differences from `/validate-ai`
 
-|                          | `/validate-ai-local`                             | `/validate-ai`                                                                       |
-| ------------------------ | ------------------------------------------------ | ------------------------------------------------------------------------------------ |
-| Input                    | Working tree + branch commits                    | A pull request                                                                       |
-| Shell script checks      | Runs them                                        | Left to the workflow's own steps                                                     |
-| `.claude-pr/` trust rule | Not applicable                                   | Applied when the snapshot exists                                                     |
-| Output                   | `validation-summary.md` in the working directory | `/tmp/validation-summary.md`, plus a sticky pull request comment in interactive mode |
+|                          | `/validate-ai-local`                                              | `/validate-ai`                                                                       |
+| ------------------------ | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| Input                    | Working tree + branch commits                                     | A pull request                                                                       |
+| Shell script checks      | Runs them                                                         | Left to the workflow's own steps                                                     |
+| `.claude-pr/` trust rule | Not applicable                                                    | Applied when the snapshot exists                                                     |
+| Output                   | A timestamped report under `${CLAUDE_PLUGIN_DATA}/ai-validation/` | `/tmp/validation-summary.md`, plus a sticky pull request comment in interactive mode |
 
 ## Related documentation
 

--- a/plugins/claude-config-validator/commands/validate-ai-local/validate-ai-local.md
+++ b/plugins/claude-config-validator/commands/validate-ai-local/validate-ai-local.md
@@ -1,7 +1,7 @@
 ---
 argument-hint: "[base-ref] (defaults to the repository default branch)"
-allowed-tools: Read, Write(${CLAUDE_PLUGIN_DATA}/ai-validation/*), Grep, Glob, Task, Skill, Bash(git diff:*), Bash(git fetch:*), Bash(git rev-parse:*), Bash(git symbolic-ref:*), Bash(git ls-files:*), Bash(date:*), Bash(ls:*)
-description: Validate the Claude Code material you changed locally (plugins, skills, agents, commands, hooks, CLAUDE.md, .claude/) and write the report to a local file
+allowed-tools: Read, Write(~/.claude/plugins/data/**/ai-validation/*), Grep, Glob, Task, Skill, Bash(git diff:*), Bash(git fetch:*), Bash(git rev-parse:*), Bash(git symbolic-ref:*), Bash(git ls-files:*), Bash(date:*), Bash(ls:*)
+description: Validate the Claude Code material you changed locally (plugins, skills, agents, commands, hooks, CLAUDE.md, .claude/) and write a timestamped report to the plugin's data directory
 ---
 
 Validate the Claude Code material changed in this checkout, the same way the

--- a/plugins/claude-config-validator/commands/validate-ai-local/validate-ai-local.md
+++ b/plugins/claude-config-validator/commands/validate-ai-local/validate-ai-local.md
@@ -1,6 +1,6 @@
 ---
 argument-hint: "[base-ref] (defaults to the repository default branch)"
-allowed-tools: Read, Write(~/.claude/plugins/data/claude-config-validator-*/ai-validation/*), Grep, Glob, Task, Skill, Bash(git diff:*), Bash(git fetch:*), Bash(git rev-parse:*), Bash(git symbolic-ref:*), Bash(git ls-files:*), Bash(date:*), Bash(ls:*)
+allowed-tools: Read, Edit(~/.claude/plugins/data/claude-config-validator-*/ai-validation/*), Grep, Glob, Task, Skill, Bash(git diff:*), Bash(git fetch:*), Bash(git rev-parse:*), Bash(git symbolic-ref:*), Bash(git ls-files:*), Bash(date:*)
 description: Validate the Claude Code material you changed locally (plugins, skills, agents, commands, hooks, CLAUDE.md, .claude/) and write a timestamped report to the plugin's data directory
 ---
 

--- a/plugins/claude-config-validator/commands/validate-ai-local/validate-ai-local.md
+++ b/plugins/claude-config-validator/commands/validate-ai-local/validate-ai-local.md
@@ -1,6 +1,6 @@
 ---
 argument-hint: "[base-ref] (defaults to the repository default branch)"
-allowed-tools: Read, Write(~/.claude/plugins/data/*/ai-validation/*), Grep, Glob, Task, Skill, Bash(git diff:*), Bash(git fetch:*), Bash(git rev-parse:*), Bash(git symbolic-ref:*), Bash(git ls-files:*), Bash(date:*), Bash(ls:*)
+allowed-tools: Read, Write(~/.claude/plugins/data/claude-config-validator-*/ai-validation/*), Grep, Glob, Task, Skill, Bash(git diff:*), Bash(git fetch:*), Bash(git rev-parse:*), Bash(git symbolic-ref:*), Bash(git ls-files:*), Bash(date:*), Bash(ls:*)
 description: Validate the Claude Code material you changed locally (plugins, skills, agents, commands, hooks, CLAUDE.md, .claude/) and write a timestamped report to the plugin's data directory
 ---
 

--- a/plugins/claude-config-validator/commands/validate-ai-local/validate-ai-local.md
+++ b/plugins/claude-config-validator/commands/validate-ai-local/validate-ai-local.md
@@ -1,6 +1,6 @@
 ---
 argument-hint: "[base-ref] (defaults to the repository default branch)"
-allowed-tools: Read, Write(validation-summary.md), Grep, Glob, Task, Skill, Bash(git diff:*), Bash(git fetch:*), Bash(git rev-parse:*), Bash(git symbolic-ref:*), Bash(git ls-files:*), Bash(ls:*)
+allowed-tools: Read, Write(${CLAUDE_PLUGIN_DATA}/ai-validation/*), Grep, Glob, Task, Skill, Bash(git diff:*), Bash(git fetch:*), Bash(git rev-parse:*), Bash(git symbolic-ref:*), Bash(git ls-files:*), Bash(date:*), Bash(ls:*)
 description: Validate the Claude Code material you changed locally (plugins, skills, agents, commands, hooks, CLAUDE.md, .claude/) and write the report to a local file
 ---
 
@@ -150,10 +150,14 @@ directly from the working tree. There is no `.claude-pr/` snapshot to redirect t
 
 ## 7. Write the report
 
-Write the full report to `validation-summary.md` in the current working directory. That is
-where the `Write(validation-summary.md)` grant resolves: a bare pattern anchors at the
-current directory, and only the `//` form is absolute. Follow the report contract in the
-scope reference, and end the report with
+Write the full report to
+`${CLAUDE_PLUGIN_DATA}/ai-validation/<repo>-<timestamp>-validation.md`, where `<repo>` is
+the basename of `git rev-parse --show-toplevel` and `<timestamp>` comes from
+`date +%Y-%m-%d-%H%M%S`. The directory is outside any repository, so the report never needs
+a `.gitignore` entry in whichever checkout you ran against, and the repo and timestamp in
+the name keep reports from different checkouts apart.
+
+Follow the report contract in the scope reference, and end the report with
 `<!-- validation-complete -->` on a line of its own. One Write call, once, after every
 subagent has returned. Writing it is mandatory — write it even when everything passed and
 even when every section was skipped.

--- a/plugins/claude-config-validator/commands/validate-ai-local/validate-ai-local.md
+++ b/plugins/claude-config-validator/commands/validate-ai-local/validate-ai-local.md
@@ -157,6 +157,11 @@ the basename of `git rev-parse --show-toplevel` and `<timestamp>` comes from
 a `.gitignore` entry in whichever checkout you ran against, and the repo and timestamp in
 the name keep reports from different checkouts apart.
 
+If `${CLAUDE_PLUGIN_DATA}` reaches you unexpanded, which can happen on a local
+`--plugin-dir` load, write to `~/.claude/plugins/data/claude-config-validator/ai-validation/`
+instead. Never fall back to the working directory: landing the report in whichever
+repository you validated is the outcome this path exists to avoid.
+
 Follow the report contract in the scope reference, and end the report with
 `<!-- validation-complete -->` on a line of its own. One Write call, once, after every
 subagent has returned. Writing it is mandatory — write it even when everything passed and

--- a/plugins/claude-config-validator/commands/validate-ai-local/validate-ai-local.md
+++ b/plugins/claude-config-validator/commands/validate-ai-local/validate-ai-local.md
@@ -1,6 +1,6 @@
 ---
 argument-hint: "[base-ref] (defaults to the repository default branch)"
-allowed-tools: Read, Write(~/.claude/plugins/data/**/ai-validation/*), Grep, Glob, Task, Skill, Bash(git diff:*), Bash(git fetch:*), Bash(git rev-parse:*), Bash(git symbolic-ref:*), Bash(git ls-files:*), Bash(date:*), Bash(ls:*)
+allowed-tools: Read, Write(~/.claude/plugins/data/*/ai-validation/*), Grep, Glob, Task, Skill, Bash(git diff:*), Bash(git fetch:*), Bash(git rev-parse:*), Bash(git symbolic-ref:*), Bash(git ls-files:*), Bash(date:*), Bash(ls:*)
 description: Validate the Claude Code material you changed locally (plugins, skills, agents, commands, hooks, CLAUDE.md, .claude/) and write a timestamped report to the plugin's data directory
 ---
 

--- a/plugins/claude-config-validator/commands/validate-ai-local/validate-ai-local.md
+++ b/plugins/claude-config-validator/commands/validate-ai-local/validate-ai-local.md
@@ -1,6 +1,6 @@
 ---
 argument-hint: "[base-ref] (defaults to the repository default branch)"
-allowed-tools: Read, Edit(~/.claude/plugins/data/claude-config-validator-*/ai-validation/*), Grep, Glob, Task, Skill, Bash(git diff:*), Bash(git fetch:*), Bash(git rev-parse:*), Bash(git symbolic-ref:*), Bash(git ls-files:*), Bash(date:*)
+allowed-tools: Read, Edit(~/.claude/plugins/data/claude-config-validator*/ai-validation/*), Grep, Glob, Task, Skill, Bash(git diff:*), Bash(git fetch:*), Bash(git rev-parse:*), Bash(git symbolic-ref:*), Bash(git ls-files:*), Bash(date:*), Bash(ls:*)
 description: Validate the Claude Code material you changed locally (plugins, skills, agents, commands, hooks, CLAUDE.md, .claude/) and write a timestamped report to the plugin's data directory
 ---
 

--- a/plugins/claude-config-validator/commands/validate-ai/README.md
+++ b/plugins/claude-config-validator/commands/validate-ai/README.md
@@ -123,8 +123,10 @@ rather than by its turn count.
 ## Permissions
 
 The command pre-approves only read-only inspection: `gh pr view`, `gh pr diff`,
-`git rev-parse`, `ls`, and reading `GITHUB_ACTIONS`. `Write` is
-scoped to the one file the command produces, `//tmp/validation-summary.md`. The `gh api`
+`git rev-parse`, and reading `GITHUB_ACTIONS`. An `Edit` rule is scoped to the one file the
+command produces, `//tmp/validation-summary.md`. It is an `Edit` rule rather than a `Write`
+one because Claude Code consults `Edit(path)` and `Read(path)` rules only, and an `Edit`
+rule covers every built-in tool that edits files. The `gh api`
 calls that create or edit the sticky comment in interactive mode are left out on purpose,
 so writing to a pull request is a decision you see and approve. Allowlist them yourself if
 you run this often.

--- a/plugins/claude-config-validator/commands/validate-ai/README.md
+++ b/plugins/claude-config-validator/commands/validate-ai/README.md
@@ -123,10 +123,12 @@ rather than by its turn count.
 ## Permissions
 
 The command pre-approves only read-only inspection: `gh pr view`, `gh pr diff`,
-`git rev-parse`, and reading `GITHUB_ACTIONS`. An `Edit` rule is scoped to the one file the
-command produces, `//tmp/validation-summary.md`. It is an `Edit` rule rather than a `Write`
-one because Claude Code consults `Edit(path)` and `Read(path)` rules only, and an `Edit`
-rule covers every built-in tool that edits files. The `gh api`
+`git rev-parse`, `ls`, and reading `GITHUB_ACTIONS`. An `Edit(//tmp/validation-summary.md)`
+rule scopes the one file the command produces, `/tmp/validation-summary.md` — the doubled
+slash is permission-rule syntax for "absolute from the filesystem root", not part of the
+path. It is an `Edit` rule rather than a `Write` one because Claude Code consults
+`Edit(path)` and `Read(path)` rules only, and an `Edit` rule covers every built-in tool that
+edits files; that needs Claude Code 2.1.210 or later. The `gh api`
 calls that create or edit the sticky comment in interactive mode are left out on purpose,
 so writing to a pull request is a decision you see and approve. Allowlist them yourself if
 you run this often.

--- a/plugins/claude-config-validator/commands/validate-ai/validate-ai.md
+++ b/plugins/claude-config-validator/commands/validate-ai/validate-ai.md
@@ -1,6 +1,6 @@
 ---
 argument-hint: "[PR#] | [PR URL] | (blank for the checked-out PR)"
-allowed-tools: Read, Edit(//tmp/validation-summary.md), Grep, Glob, Task, Skill, Bash(gh pr view:*), Bash(gh pr diff:*), Bash(git rev-parse:*), Bash(printenv GITHUB_ACTIONS)
+allowed-tools: Read, Edit(//tmp/validation-summary.md), Grep, Glob, Task, Skill, Bash(gh pr view:*), Bash(gh pr diff:*), Bash(git rev-parse:*), Bash(printenv GITHUB_ACTIONS), Bash(ls:*)
 description: Validate the Claude Code material changed in a pull request (plugins, skills, agents, commands, hooks, CLAUDE.md, .claude/) and report results to the pull request
 ---
 

--- a/plugins/claude-config-validator/commands/validate-ai/validate-ai.md
+++ b/plugins/claude-config-validator/commands/validate-ai/validate-ai.md
@@ -1,6 +1,6 @@
 ---
 argument-hint: "[PR#] | [PR URL] | (blank for the checked-out PR)"
-allowed-tools: Read, Write(//tmp/validation-summary.md), Grep, Glob, Task, Skill, Bash(gh pr view:*), Bash(gh pr diff:*), Bash(git rev-parse:*), Bash(printenv GITHUB_ACTIONS), Bash(ls:*)
+allowed-tools: Read, Edit(//tmp/validation-summary.md), Grep, Glob, Task, Skill, Bash(gh pr view:*), Bash(gh pr diff:*), Bash(git rev-parse:*), Bash(printenv GITHUB_ACTIONS)
 description: Validate the Claude Code material changed in a pull request (plugins, skills, agents, commands, hooks, CLAUDE.md, .claude/) and report results to the pull request
 ---
 

--- a/plugins/claude-config-validator/skills/reviewing-claude-config/SKILL.md
+++ b/plugins/claude-config-validator/skills/reviewing-claude-config/SKILL.md
@@ -97,7 +97,7 @@ Load reference files only when needed for specific questions:
 - **Issue prioritization** → `reference/priority-framework.md` (CRITICAL vs IMPORTANT vs SUGGESTED vs OPTIONAL)
 - **Security patterns** → `reference/security-patterns.md` (detection commands, fix examples)
 - **Claude Code requirements** → `reference/claude-code-requirements.md` (YAML frontmatter, model selection, tool names, progressive disclosure, settings conventions)
-- **Whole-changeset review** → `reference/validate-ai-scope.md` (which paths count as Claude material, which validations each bucket gates, and the structured report contract used by the `/validate-ai` and `/validate-ai-local` commands). Its report-writing and subagent instructions address those commands, which hold the `Write` and `Task` grants this skill does not.
+- **Whole-changeset review** → `reference/validate-ai-scope.md` (which paths count as Claude material, which validations each bucket gates, and the structured report contract used by the `/validate-ai` and `/validate-ai-local` commands). Its report-writing and subagent instructions address those commands, which hold the report-writing and `Task` grants this skill does not.
 
 ### Step 5: Document Findings
 


### PR DESCRIPTION
## 🎟️ Tracking

Follow-up to #197, addressing https://github.com/bitwarden/ai-plugins/pull/197#discussion_r3785900171.

## 📔 Objective

`/validate-ai-local` wrote its report to `validation-summary.md` in the current working directory. That command runs against any checkout, so the report could land in any repository root, meaning every repo it gets pointed at would need its own `.gitignore` entry to keep the report out of a commit. This repo carried that entry; no other repo did.

Reports now go to `${CLAUDE_PLUGIN_DATA}/ai-validation/<repo>-<timestamp>-validation.md`, which resolves under `~/.claude/plugins/data/`. Since that sits outside every checkout, no repository needs a `.gitignore` entry for it, and the repo name and timestamp keep runs against different checkouts from overwriting each other. This matches what `bitwarden-code-review` and `bitwarden-testing-tools` already do with `${CLAUDE_PLUGIN_DATA}/code-reviews/` and `.../coverage-reports/`.

The reviewer's noted downside still applies: reports accumulate somewhere you would not stumble across, and `claude plugin uninstall` drops them unless you pass `--keep-data`. The command prints the path it wrote, and the README documents the location and the trade-off.

### The report grants are now `Edit` rules, which fixed a live bug in `/validate-ai`

Several review rounds circled the report's permission grant. The answer was simpler than the anchoring debate that got us there, and it came from the permissions reference:

> Claude Code checks file permissions against `Edit(path)` and `Read(path)` rules only. If you write a path rule for `Write`, `NotebookEdit`, `Glob`, or the legacy `MultiEdit` tool instead, Claude Code accepts the rule but never consults it, and warns at startup [...] Use `Edit(docs/**)` in place of `Write(docs/**)`. Requires Claude Code v2.1.210 or later.

So every `Write(path)` rule in this plugin was inert regardless of how it was anchored, and the earlier rounds of `//` versus `~/` versus `**` versus `*` were arguing about a rule nothing was reading. The grant is now `Edit(~/.claude/plugins/data/claude-config-validator*/ai-validation/*)`. An `Edit` rule applies to every built-in tool that edits files, and `allowed-tools` pre-approves rather than restricting availability, so the `Write` tool stays callable under that rule's path.

That also surfaced a live bug outside this change's original scope, which I fixed here: `/validate-ai` declared `Write(//tmp/validation-summary.md)`, equally inert, for a write its own body marks mandatory. That command runs non-interactively in CI, where nobody can answer a permission prompt. It is now an `Edit` rule too. Happy to split it into its own PR if you would rather keep this one narrow.

One related correction, since I got the reasoning wrong on an earlier push. I had documented the `Edit` rule's literal path as necessary because substitution in `allowed-tools` is documented for Bash rules only. That is true of the published docs but not of the CLI, which substitutes the whole `allowed-tools` value regardless of rule type, so the variable form would in fact have worked for a marketplace install. The real reason is narrower and stronger: substitution is guarded on the plugin having a marketplace source, so a local `--plugin-dir` load can leave the variable unexpanded. A literal path covers both install kinds. Step 7 now also states a fallback for that case, pointing at the bare-id directory the `Edit` glob already covers, and rules out ever falling back to the working directory.

### Also from the reviews

- Removed the `validation-summary.md` line from `.gitignore`, which is the point of the change: nothing writes that filename into a working directory any more, since `/validate-ai-local` writes under the plugin data directory and `/validate-ai` writes `/tmp`. Anyone still on 1.2.0 can surface an untracked report in a checkout until they upgrade. That risk is accepted rather than overlooked, since `git status` shows the file and committing it takes a deliberate `git add`. The `review-summary.md` and `review-inline-comments.md` lines stay, because `bitwarden-code-review` still writes those to the working directory.
- Scoped the grant to this plugin with a `claude-config-validator*` prefix glob, which names the plugin while globbing the marketplace suffix in its install id. A bare `*` in that position covered every installed plugin's `ai-validation/` directory. The trailing glob is deliberately loose: a required hyphen matches a marketplace install but not a local `--plugin-dir` load, whose install id has no suffix.
- Corrected the environment-variable caveat. Both `CLAUDE_CONFIG_DIR` and `CLAUDE_CODE_PLUGIN_CACHE_DIR` relocate the tree the rule is written against, each confirmed by pointing it elsewhere and watching `claude plugin list` come up empty.
- Fixed the `--keep-data` attribution. It is a flag of the `claude plugin uninstall` CLI subcommand, not the interactive `/plugin` manager, so the instruction now runs as written.
- Recorded the Claude Code 2.1.210 floor that the `Edit`-covers-`Write` behavior needs. On an older CLI the write asks for permission, which is the pre-existing behavior rather than a new failure.
- Documented the Linux sandbox interaction. With the Bash sandbox on, Claude Code warns at startup that glob patterns in permission rules are not fully supported when it derives sandbox write paths, and the warning names this rule. The report is still written, because the permission check the write goes through is a separate path.
- The command `description` now names the report location, since that string is what `/help` and the command listing surface.
- Stopped reusing `//tmp/validation-summary.md` in prose as if the doubled slash were part of the path, and dropped the stale "`Write` grant" wording from the skill.

Two regressions I introduced mid-review and then backed out. I dropped `Bash(ls:*)` from both commands after grepping for a literal `ls` and finding none. That check was too literal: step 3 probes `$BW_GH_ACTIONS_PATH/validate-ai/scripts`, and `ls` was the only granted tool that can resolve a path behind an environment variable, so removing it cost a permission prompt on the script lookup. It is restored, and the changelog no longer calls it unexercised. The `claude-config-validator-*` glob was the second, fixed above.

I also ran `/validate-ai-local` against this branch. All three shell checks pass. Worth noting what actually ran: the installed plugin is the published 1.2.0 rather than this working tree, so the command wrote its report into the repository root, which is the behavior this PR changes. That leaves one thing static reading cannot settle. Someone should run the command from a checkout where this branch is the installed plugin and confirm the write lands under the plugin data directory without prompting.

Version bumped 1.2.0 → 1.2.1 across `marketplace.json`, `plugin.json`, and the README catalog, with `### Changed` and `### Fixed` entries. No `agents/` directory, so no `AGENT.md` to bump.

### Pre-existing findings, deliberately deferred

Review surfaced four defects that predate this change. All are left alone on purpose, to keep this PR to the report location. The two the validator classified as major are its own words on scope: "Neither was introduced by this pull request and neither blocks it."

- `skills/reviewing-claude-config/SKILL.md:116` (major) makes inline pull request comments the bolded-CRITICAL default output mode, but the skill's `allowed-tools` is `Read, Grep, Glob`, so nothing can post a comment. Only `/validate-ai` and `/validate-ai-local` are exempted, which leaves the default path unexecutable on every direct invocation.
- `skills/reviewing-claude-config/SKILL.md:179` (major) instructs the reviewer to activate `Skill(detecting-secrets)`, but `Skill` is not among the skill's grants, so that line is dead on the direct-invocation path. It works through either command, since both hold `Skill`.
- `commands/validate-ai-local/validate-ai-local.md:3` grants `Bash(git fetch:*)` where step 1 only ever runs `git fetch origin <branch>`, so the prefix also pre-approves fetching arbitrary remotes.
- `commands/validate-ai/validate-ai.md:3` writes a predictable path in a world-writable directory. On a shared host in interactive mode, a pre-planted symlink at `/tmp/validation-summary.md` would be followed without a prompt, and the report is world-readable. Largely forced, since the `bitwarden/gh-actions` workflow reads that exact path and CI runners are ephemeral.

The two `SKILL.md` items belong together in a follow-up, since fixing them means deciding how the skill describes its own output mode and grants. This PR touches that file only to correct one stale word.

Also out of scope: `/code-review-local` in `bitwarden-code-review` still writes `review-summary.md` and `review-inline-comments.md` to the working directory, and those `.gitignore` entries stay. If we want the convention uniform, that command deserves the same treatment in its own PR.
