### PR TITLE
[AI-88] docs: Update reference to the retired Claude context guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ For general Bitwarden contribution practices, see our [Contributing Guidelines](
 
 ## Where Does Your Claude Tooling Belong?
 
-Plugins in this marketplace fall into three families. Repo-specific patterns usually belong closer to the code — see each repo's `.claude/CONTRIBUTING.md` for that. If your work is cross-repo and fits one of the families below, you're in the right place. If you're still unsure after reading them, raise a draft PR and maintainers will help find the right home.
+Plugins in this marketplace fall into three families. Repo-specific patterns usually belong closer to the code, in that repo's `.claude/` directory. If your work is cross-repo and fits one of the families below, you're in the right place. If you're still unsure after reading them, raise a draft PR and maintainers will help find the right home.
 
 ### Persona Plugins
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/AI-88

## 📔 Objective

The per-repo Claude context guide is being retired in favour of the single org-level guide in `contributing-docs`, so our routing sentence here pointed at a file that no longer exists in any repo. It now sends repo-specific patterns to that repo's `.claude/` directory instead, which is the advice that still holds. **No deletion in this repo**, since it never carried a copy of the guide itself.
