### PR TITLE
fix(claude-config-validator): stop two skills failing to load on quoted shell syntax

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -18,7 +18,7 @@
     {
       "name": "claude-config-validator",
       "source": "./plugins/claude-config-validator",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "description": "Validates Claude Code configuration files for security, structure, and quality. Routes CLAUDE.md, agents, commands, hooks, and settings to targeted review skills, reporting only what a changeset introduced."
     },
     {

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A curated collection of plugins for AI-assisted development at Bitwarden. Enable
 | [bitwarden-security-engineer](plugins/bitwarden-security-engineer/) | 1.3.0   | Application security engineering: vulnerability triage, threat modeling, and secure code analysis                                                           |
 | [bitwarden-software-engineer](plugins/bitwarden-software-engineer/) | 1.0.0   | Software engineer agent for a Bitwarden product team. Implements stories, tasks, and bugs with code quality, performance, security, and team comms in mind. |
 | [bitwarden-testing-tools](plugins/bitwarden-testing-tools/)         | 1.0.0   | Testing tools for analyzing and improving test quality across Bitwarden's repositories.                                                                     |
-| [claude-config-validator](plugins/claude-config-validator/)         | 2.0.0   | Validates Claude Code configuration files for security, structure, and quality                                                                              |
+| [claude-config-validator](plugins/claude-config-validator/)         | 2.0.1   | Validates Claude Code configuration files for security, structure, and quality                                                                              |
 | [claude-retrospective](plugins/claude-retrospective/)               | 1.1.1   | Analyze Claude Code sessions to identify successful patterns and improvement opportunities                                                                  |
 
 ## Usage

--- a/plugins/claude-config-validator/.claude-plugin/plugin.json
+++ b/plugins/claude-config-validator/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-config-validator",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Validates Claude Code configuration files for security, structure, and quality. Routes CLAUDE.md, agents, commands, hooks, and settings to targeted review skills, reporting only what a changeset introduced.",
   "author": {
     "name": "Bitwarden",

--- a/plugins/claude-config-validator/CHANGELOG.md
+++ b/plugins/claude-config-validator/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the Claude Config Validator Plugin will be documented in 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] - 2026-08-21
+
+### Fixed
+
+- `reviewing-claude-config` and `reviewing-command-definitions` failed to load: both quoted the literal bash-execution syntax, which Claude Code expands in any file it loads, in inline code spans and fenced blocks alike
+- `reviewing-command-definitions` names the construct rather than reproducing it, and says why, so the syntax is not reintroduced
+
 ## [2.0.0] - 2026-08-19
 
 ### Added

--- a/plugins/claude-config-validator/skills/reviewing-claude-config/SKILL.md
+++ b/plugins/claude-config-validator/skills/reviewing-claude-config/SKILL.md
@@ -232,7 +232,7 @@ holds:
   permission, tool grant, or hook capability wider than what the changeset justifies, and any
   new path by which contributor-controlled input reaches a shell. Hook input is the one
   exception: quoted and consumed directly by the command it is passed to, it is not such a
-  path. A slash command has no safe quoted form, so any interpolation into a `` !`...` ``
+  path. A slash command has no safe quoted form, so any interpolation into a bash-execution
   block is one.
 
 A widening the changeset justifies is not a finding at all, so it never reaches this rule.

--- a/plugins/claude-config-validator/skills/reviewing-claude-config/reference/validate-ai-scope.md
+++ b/plugins/claude-config-validator/skills/reviewing-claude-config/reference/validate-ai-scope.md
@@ -216,7 +216,7 @@ plugin loading (malformed manifest, missing required file) and major otherwise
   tool grant, or hook capability wider than what the changeset justifies, and any new path by
   which contributor-controlled input reaches a shell. Hook input quoted and consumed directly
   by the command it is passed to is the one exception; a slash command has no safe quoted
-  form, so any interpolation into a `` !`...` `` block counts, or
+  form, so any interpolation into a bash-execution block counts, or
 - a failed script check.
 
 Everything else reports as `Pass` with its findings listed underneath.

--- a/plugins/claude-config-validator/skills/reviewing-command-definitions/SKILL.md
+++ b/plugins/claude-config-validator/skills/reviewing-command-definitions/SKILL.md
@@ -46,8 +46,8 @@ yours. Pass 2 is yours too, unless you can confirm the validator covered that sp
 
 Also run the router's credential scan over any command you review directly, using the patterns
 in `../reviewing-claude-config/reference/security-patterns.md`. A bearer token inside a
-`` !`curl -H ...` `` block is the shape to look for; Pass 7 reads those blocks for injection,
-not for embedded credentials.
+bash-execution block running `curl -H ...` is the shape to look for; Pass 7 defines the term
+and reads those blocks for injection, not for embedded credentials.
 
 ## Pass 1: Purpose and usage
 
@@ -190,24 +190,29 @@ use. Verify with `Glob` rather than from memory; skill names change.
 This is the security surface of a slash command, and no sibling skill covers it: the router
 sends every command path here.
 
-- [ ] `` !`cmd` `` blocks are read as executable code. They run at prompt-expansion time,
+A **bash-execution block** is an exclamation mark placed immediately before a backtick-quoted
+command. This file never writes that form out, and neither should any other file Claude loads:
+the expansion happens on the raw text, so inline code spans and fenced code blocks are both
+expanded, and a file that quotes the syntax fails to load with a shell error. Name the
+construct instead, and show the command on its own.
+
+- [ ] Bash-execution blocks are read as executable code. They run at prompt-expansion time,
       before the model sees anything, so a `PreToolUse` hook never fires on them
-- [ ] No `$ARGUMENTS`, `$1`, or `$2` is interpolated into a shell string inside `` !`...` ``.
+- [ ] No `$ARGUMENTS`, `$1`, or `$2` is interpolated into a shell string inside one.
       **Quoting is not a fix.** Any interpolation is CRITICAL, quoted or not: a slash command
       has no safe quoted form
 - [ ] Where the command needs its arguments, they arrive on stdin, or are validated against an
       allowlist such as `^[0-9]+$` before use
-- [ ] The `allowed-tools` grant names the exact commands any `` !`...` `` block runs
+- [ ] The `allowed-tools` grant names the exact commands any bash-execution block runs
 
 Substitution is textual and happens before the shell parses the line, which is why quoting
-narrows the hole without closing it. A command containing:
+narrows the hole without closing it. Take a command whose body holds a bash-execution block
+around:
 
-```markdown
-!`gh pr view $ARGUMENTS`
-```
+    gh pr view $ARGUMENTS
 
-invoked as `/review-pr 1; rm -rf ~` expands to `gh pr view 1; rm -rf ~`, and the shell runs both
-clauses. Adding quotes stops that particular payload and two others still work:
+Invoked as `/review-pr 1; rm -rf ~` it expands to `gh pr view 1; rm -rf ~`, and the shell runs
+both clauses. Adding quotes stops that particular payload and two others still work:
 
 - `/review-pr $(rm -rf ~)` expands to `gh pr view "$(rm -rf ~)"`. Command substitution runs
   inside double quotes.


### PR DESCRIPTION
## 🎟️ Tracking

Fixes a regression shipped by #201. Found by the `/validate-ai` run on #206, which could not load the router skill and had to substitute manual steps for it.

Independent of #206 and #203 — based on `main`, touches no file either of them touches.

## 📔 Objective

`claude-config-validator` 2.0.0 is unusable. Two of its five skills fail to load:

```
Shell command failed for pattern "!`...`"
```

Claude Code expands a bash-execution block on the raw text of any file it loads. Both skills quote that syntax in order to teach it, so loading them runs the quoted fragment as a shell command and the load fails. `reviewing-claude-config` is the router every caller enters through, so the whole plugin is affected, including the four cross-plugin callers.

### Fenced code blocks are not a safe haven

Worth stating plainly, because it is the non-obvious part and it caught me mid-fix. My first pass left one example inside a fenced block on the assumption that fencing suppressed expansion. It does not. `plugin-dev:command-development` fails to load for exactly this reason:

```
Shell command failed for pattern "!`node .../scripts/analyze.js $1`"
Error: Cannot find module '.../plugin-dev/unknown/scripts/analyze.js'
```

That block sits inside a fenced example in upstream's own skill. Inline code spans and fenced blocks are both expanded, so the only safe rule is that a file Claude loads must never contain the literal form.

### Approach

`reviewing-command-definitions` defines the term **bash-execution block** once and uses it thereafter, with a sentence saying why the syntax is never written out, so a future edit does not reintroduce it. The worked injection example keeps its payloads and its expansion, and shows the command on its own line instead of wrapped in the trigger.

`reviewing-claude-config` and `validate-ai-scope.md` each had one occurrence in prose and now use the same term. The reference file is only ever read with `Read`, never loaded, so it was not part of the failure — it is changed for consistency and to keep it from being copied into a file that is loaded.

The 2.0.0 changelog entry still contains the literal form. Changelogs are never loaded, and rewriting a shipped release entry seemed worse than leaving it.

Version `2.0.0` to `2.0.1`.

### Verification

The mechanism is demonstrated rather than assumed: `plugin-dev:command-development` reproduces the failure on demand, which is what established that fenced blocks expand. `git grep '!\`'` over `plugins/` now returns only the historical changelog line. Lint, plugin structure, marketplace, and version-bump checks all pass.

I have not loaded the patched skills end to end, since that needs the plugin installed from this branch rather than the marketplace. The argument is that the failure is deterministic on a pattern that no longer appears in any loaded file.

### Follow-up, not fixed here

`plugin-dev:command-development` is broken upstream in `anthropics/claude-code` for the same reason. Worth reporting there; it is the skill that documents this syntax, so it has the strongest reason to quote it and the least room to avoid it.

Nothing in this plugin detects the fault. A skill that fails to load is invisible to every check we run, since the validators read files rather than load them. A grep for the literal form in any `SKILL.md` or command file would be cheap and belongs in a later change.

### Merge order

Both this and #203 bump `claude-config-validator` to `2.0.1`. #203 is stacked behind #206, so this should land first and #203 moves to `2.0.2`.
