### PR TITLE
[AI-52] feat: Pin aikido as an external plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -104,6 +104,21 @@
       "source": "./plugins/bitwarden-testing-tools",
       "version": "1.1.0",
       "description": "Testing tools for Bitwarden — analyzing and improving test quality across its repositories."
+    },
+    {
+      "name": "aikido",
+      "description": "Aikido Security for Claude Code: scan code (SAST, secrets, IaC) and list all issues from your Aikido feed powered by the Aikido MCP server.",
+      "author": {
+        "name": "Aikido Security",
+        "url": "https://aikido.dev"
+      },
+      "category": "external",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/AikidoSec/aikido-claude-plugin.git",
+        "sha": "1353c9d54b387f259f0c04f0ed3408842203c29e"
+      },
+      "homepage": "https://github.com/AikidoSec/aikido-claude-plugin"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -116,7 +116,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/AikidoSec/aikido-claude-plugin.git",
-        "sha": "1353c9d54b387f259f0c04f0ed3408842203c29e"
+        "sha": "868d7ce08e6ee6fc4fbb539a07d2ec7bc1d7482d"
       },
       "homepage": "https://github.com/AikidoSec/aikido-claude-plugin"
     }

--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ A curated collection of plugins for AI-assisted development at Bitwarden. Enable
 | [claude-config-validator](plugins/claude-config-validator/)         | 2.0.2   | Validates Claude Code configuration files for security, structure, and quality                                                                              |
 | [claude-retrospective](plugins/claude-retrospective/)               | 1.1.1   | Analyze Claude Code sessions to identify successful patterns and improvement opportunities                                                                  |
 
+### External plugins
+
+Sourced from outside Bitwarden and **pinned to a reviewed commit**, following the pattern Anthropic uses for third-party entries in its own marketplace. Their files are not copied into this repo; each entry references an upstream repository at a fixed commit.
+
+| Plugin                                                        | Author          | Description                                                                                                |
+| ------------------------------------------------------------- | --------------- | ---------------------------------------------------------------------------------------------------------- |
+| [`aikido`](https://github.com/AikidoSec/aikido-claude-plugin) | Aikido Security | Scan code (SAST, secrets, IaC) and list all issues from your Aikido feed powered by the Aikido MCP server. |
+
 ## Usage
 
 ### Adding this marketplace to Claude Code


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/AI-52

## 📔 Objective

Pins `aikido` (`AikidoSec/aikido-claude-plugin`) as an external plugin entry in `marketplace.json` at commit `1353c9d`. No files are copied into this repo; the entry references the upstream repository at a fixed commit, with a new "External plugins" README section for this category.

> [!NOTE]
> HEAD -1 sha pinned to facilitate testing of the Renovate config in #232   