### PR TITLE
[AI-52] feat: Trigger external plugin pin audits in CI

### DIFF
--- a/.github/workflows/audit-external-plugin.yml
+++ b/.github/workflows/audit-external-plugin.yml
@@ -1,0 +1,22 @@
+name: Audit External Claude Plugin
+
+on:
+  pull_request:
+    paths:
+      - ".claude-plugin/marketplace.json"
+
+permissions: {}
+
+jobs:
+  audit:
+    name: Audit External Claude Plugin
+    uses: bitwarden/gh-actions/.github/workflows/_audit-external-claude-plugin.yml@main
+    secrets:
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      pull-requests: write


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/AI-52

## 📔 Objective

Adds a thin caller workflow that triggers on `.claude-plugin/marketplace.json` changes and delegates to `bitwarden/gh-actions`'s `_audit-external-claude-plugin.yml` reusable workflow, which audits any new or updated external plugin pin via `auditing-external-claude-plugins`.
